### PR TITLE
feat(typescript): ChessReferee — endpoint-backed vision + client-side stockfish.wasm

### DIFF
--- a/examples/typescript/chess-referee/.env.example
+++ b/examples/typescript/chess-referee/.env.example
@@ -1,0 +1,15 @@
+# Copy to .env (gitignored — never commit real keys):
+#   cp .env.example .env
+
+# From your Cosmo workspace (Developer platform → API keys); needs the
+# realtime:use scope. Also sent as the bearer token to the board-vision
+# endpoint. Optional here — the app lets you paste it at runtime.
+VITE_COSMO_API_KEY=
+
+# Which Cosmo backend to connect to. Both the realtime session and the
+# board-vision endpoint live on this host.
+VITE_COSMO_BASE_URL=https://platform.askcosmo.ai
+
+# NOTE: VITE_* variables are inlined into the built bundle by Vite. They're
+# fine for local dev, but don't run `npm run build` with a real key in here
+# and then serve dist/ — you'd be publishing the key.

--- a/examples/typescript/chess-referee/.gitignore
+++ b/examples/typescript/chess-referee/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+dist/
+.env

--- a/examples/typescript/chess-referee/.gitignore
+++ b/examples/typescript/chess-referee/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .env
+public/stockfish/

--- a/examples/typescript/chess-referee/README.md
+++ b/examples/typescript/chess-referee/README.md
@@ -22,6 +22,7 @@ the tools, and the interjection carry over unchanged.
 | `sendContext()` for silent live app state | `App.tsx` `forward()` — every move streams as a `[board]` note; the agent stays quiet |
 | Interjection: a tagged `sendText(…, { transcript: false })` directive | same function — on an illegal or out-of-turn move; the directive never appears in the transcript |
 | A client tool backed by an HTTP endpoint | `get_chess_board_position` in `tools.ts` — canvas frame capture, one POST, FEN back to the model |
+| A pure client tool — compute on the user's machine | `analyze_position` in `analysis/` — Stockfish wasm in a web worker, no backend round-trip |
 
 Why not `sendContext` alone? Context notes never trigger a spoken response by
 design. The referee moment is a regular text turn tagged `[referee-alert]`,
@@ -44,10 +45,37 @@ src/
   tools.ts          get_chess_board_position client tool
   instructions.ts   referee persona + the [referee-alert] contract
   App.tsx           setup form, session view, event → session wiring
+  analysis/
+    engine.ts             minimal UCI client over a message-port transport
+    stockfish_transport.ts  web-worker transport + one lazy engine per app
+    position.ts           FEN legality gate + SAN/eval rendering (chess.js)
+    analyze_core.ts       validate → search → top moves with eval and line
+    analyze_position.ts   the analyze_position client tool
 ```
 
-`analyze_position` (client-side stockfish.wasm) slots in alongside
-`get_chess_board_position` in `tools.ts` — same `ToolContext`, no server.
+## Client-side analysis (`analyze_position`)
+
+Ask the referee what to play and it consults Stockfish — compiled to
+WebAssembly, running in a web worker on the user's machine. The contract
+mirrors the Cosmo backend's `start_chess_analysis` tool, so instructions
+written against either work unchanged: the placement from
+`get_chess_board_position` goes in (passed through, never model-authored),
+top moves with eval and a short expected line come out.
+
+Two deliberate choices:
+
+- **Single-threaded lite build** (`stockfish-18-lite-single`): the
+  multithreaded builds need SharedArrayBuffer and therefore COOP/COEP
+  headers on every response, which most dev servers and static hosts don't
+  send. Single-threaded lite reaches coaching depth (~12–15) inside its
+  750 ms budget and runs anywhere.
+- **Served from `public/stockfish/`, not bundled**: the engine `.js` runs
+  directly as a worker and fetches its `.wasm` relative to its own URL;
+  `scripts/copy_stockfish.mjs` copies both there at install time.
+
+Note: the [`stockfish`](https://www.npmjs.com/package/stockfish) package is
+GPL-3.0-licensed. This example depends on it as-is; mind the license if you
+reuse this code in your own product.
 
 ## Run it
 
@@ -80,7 +108,8 @@ needs even light, a near-top-down angle, and a standard piece set. Misreads
 that survive the stability gate are classified against the rules engine, so
 the common failure mode is a missed event, not a false accusation.
 
-The referee state machine is pure TypeScript and tested:
+The referee state machine and the analysis stack are pure TypeScript and
+tested — including against the real wasm engine:
 
 ```bash
 npm test

--- a/examples/typescript/chess-referee/README.md
+++ b/examples/typescript/chess-referee/README.md
@@ -39,7 +39,7 @@ there's something worth saying.
 src/
   referee.ts        stability gate, move inference, verdicts (pure; tested)
   referee_loop.ts   capture → endpoint → referee polling loop
-  board_vision.ts   client for POST /api/v1/chess/board-position
+  board_vision.ts   client for POST /api/v1/external/chess/board-position
   frame_capture.ts  camera/screen frame → JPEG blob at capture resolution
   tools.ts          get_chess_board_position client tool
   instructions.ts   referee persona + the [referee-alert] contract

--- a/examples/typescript/chess-referee/README.md
+++ b/examples/typescript/chess-referee/README.md
@@ -1,0 +1,87 @@
+# Chess referee (endpoint-backed vision)
+
+A web app that watches a chess game through your camera — or a lichess /
+chess.com tab via screen share — and referees it out loud. Board reading
+happens on a Cosmo backend endpoint, so the browser ships **no vision model**:
+it captures a frame, POSTs it, and gets FEN back. The app checks every move
+against the rules, and when someone slips a bishop through a pawn, the voice
+agent calls it out — unprompted.
+
+This is the thin-client recipe for perception with a realtime agent:
+
+    camera → frame capture → vision endpoint → structured state → sendContext() → agent interjects
+
+It is the same referee design as the [Swift ChessReferee example](../../swift/ChessReferee/)
+with the on-device detector swapped for a hosted endpoint — the state stream,
+the tools, and the interjection carry over unchanged.
+
+## What it demonstrates
+
+| SDK surface | Where |
+| --- | --- |
+| `sendContext()` for silent live app state | `App.tsx` `forward()` — every move streams as a `[board]` note; the agent stays quiet |
+| Interjection: a tagged `sendText(…, { transcript: false })` directive | same function — on an illegal or out-of-turn move; the directive never appears in the transcript |
+| A client tool backed by an HTTP endpoint | `get_chess_board_position` in `tools.ts` — canvas frame capture, one POST, FEN back to the model |
+
+Why not `sendContext` alone? Context notes never trigger a spoken response by
+design. The referee moment is a regular text turn tagged `[referee-alert]`,
+sent with `transcript: false` so the user never sees the synthetic directive.
+
+Why is the referee logic in the app and not the agent? Vision noise. The
+endpoint misreads frames; the app requires the same position on consecutive
+reads and only accepts transitions a chess rules engine (chess.js) can
+classify. The agent gets clean, confident events — and only speaks when
+there's something worth saying.
+
+## Layout
+
+```
+src/
+  referee.ts        stability gate, move inference, verdicts (pure; tested)
+  referee_loop.ts   capture → endpoint → referee polling loop
+  board_vision.ts   client for POST /api/v1/chess/board-position
+  frame_capture.ts  camera/screen frame → JPEG blob at capture resolution
+  tools.ts          get_chess_board_position client tool
+  instructions.ts   referee persona + the [referee-alert] contract
+  App.tsx           setup form, session view, event → session wiring
+```
+
+`analyze_position` (client-side stockfish.wasm) slots in alongside
+`get_chess_board_position` in `tools.ts` — same `ToolContext`, no server.
+
+## Run it
+
+```bash
+npm install
+cp .env.example .env   # add your key, or paste it into the form at runtime
+npm run dev            # http://localhost:7870
+```
+
+The key needs the `realtime:use` scope (Developer platform → API keys); the
+same key authenticates the board-vision endpoint. For anything beyond a local
+demo, mint per-user tokens from your backend instead of embedding a workspace
+key — see the [end-user credentials guide](https://platform.askcosmo.ai/docs).
+
+**Two-minute quickstart, no chess set needed:** open lichess.org or chess.com
+in another window, pick **Screen share** as the board source, start, and share
+that window. Play a legal move, then drag a piece somewhere illegal.
+
+**Physical board:** pick **Camera**, mount the phone or webcam as close to
+top-down as you can, in even light. Set **Side nearest the camera** — at the
+starting position a board reads legally from both directions, so automatic
+orientation can lock the wrong way; telling the app which side is nearest is
+the reliable path.
+
+## Demo-grade, deliberately
+
+The endpoint's detector was trained on synthetic 2D board renders
+(lichess/chess.com style), so screen share is its home turf; a physical board
+needs even light, a near-top-down angle, and a standard piece set. Misreads
+that survive the stability gate are classified against the rules engine, so
+the common failure mode is a missed event, not a false accusation.
+
+The referee state machine is pure TypeScript and tested:
+
+```bash
+npm test
+```

--- a/examples/typescript/chess-referee/index.html
+++ b/examples/typescript/chess-referee/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Chess referee — cosmo-ai example</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/typescript/chess-referee/package-lock.json
+++ b/examples/typescript/chess-referee/package-lock.json
@@ -1,0 +1,2390 @@
+{
+  "name": "cosmo-chess-referee",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "cosmo-chess-referee",
+      "version": "0.1.0",
+      "dependencies": {
+        "chess.js": "^1.4.0",
+        "cosmo-ai": "^0.3.0",
+        "livekit-client": "^2",
+        "react": "^19",
+        "react-dom": "^19",
+        "zod": "^4.4.3"
+      },
+      "devDependencies": {
+        "@types/react": "^19",
+        "@types/react-dom": "^19",
+        "@vitejs/plugin-react": "^4",
+        "typescript": "^5",
+        "vite": "^5",
+        "vitest": "^3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.8"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.8",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.8",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@livekit/mutex": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@livekit/mutex/-/mutex-1.1.1.tgz",
+      "integrity": "sha512-EsshAucklmpuUAfkABPxJNhzj9v2sG7JuzFDL4ML1oJQSV14sqrpTYnsaOudMAw9yOaW53NU3QQTlUQoRs4czw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@livekit/protocol": {
+      "version": "1.50.4",
+      "resolved": "https://registry.npmjs.org/@livekit/protocol/-/protocol-1.50.4.tgz",
+      "integrity": "sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      }
+    },
+    "node_modules/@napi-rs/lzma-linux-x64-gnu": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/lzma-linux-x64-gnu/-/lzma-linux-x64-gnu-1.5.1.tgz",
+      "integrity": "sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^22.20 || ^24.12 || >=25"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.4.tgz",
+      "integrity": "sha512-RrPokAb7dmbxFoeO3TloqHyOjgye8RkBhSqmp4aJMIex4c9r46ZstPnleDQOq1t46VOVjwIuwNogIqbodV1Vvg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.4.tgz",
+      "integrity": "sha512-JKuJc+pnpks2pjy7L/N3v/cAkZxYlnmuZoD840ldbMI5KDbC4iO9NKwPKYdjYFCMAIIlBzYSFHxIJVYzRo2/8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.4.tgz",
+      "integrity": "sha512-krw5uS2STmvJ02x0uTXHbqQNuz+9eZ1iw+qXk9dmW2gvV4jV7O2hEoOnuhFrpOPiel1mBFtqbxYZZtC46hXLOw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.4.tgz",
+      "integrity": "sha512-wsTxtgApb4PrOsNJIm0FZ1h3WvCC+k9uxLJ4ad75hgoS4NiRes2SoJFlDAyMwiUY8IssDqGcHbXuN0sx1tfF1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.4.tgz",
+      "integrity": "sha512-GUOnQlyZe3yAXhWOtOMsn5Qkrv5E5mZXa0thbARWi5Ei2szlVXJFQhddZ4HbAzh8q92w5twp+CQvs/eFanz9YQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.4.tgz",
+      "integrity": "sha512-/Y7f3QuxjzPKsjA/rfEDa3+0vXqyjmJ50Ln8dPpCmWkKTrUoWHG1cWhTqaAMLob2m2nESWuC7yGrREz019Ztqg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.4.tgz",
+      "integrity": "sha512-81wiiX3v7aqy+T+bT61TJ78yJjRquqFFTTbAPt08imfQQzkPIW8t6aJbkTagtCCrXMNc9D66+geqlK7ydLPNqA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.4.tgz",
+      "integrity": "sha512-9kmDIvNZqdoHOBZgNtpTBeLWYO/LVipM3H/j62P8848/l/VPEQL6N3uxU9pvP1oZAsXyC2MEnFP3ovRjo7WYNQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.4.tgz",
+      "integrity": "sha512-CcnXHWnXg69g+DX5VWL3FHts3qMRN2uVEHX+BZvGLdd07/gXkn3ePjYtO1LDJvxkGKVHMclKBRa1QUTH+6toYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.4.tgz",
+      "integrity": "sha512-iFOibiHnTRuhrWLlRsOQFdZJJIa7S8OwkneJr4ocALP16u5yk6lWLINFwhHaEqBFMsKDUZofLkGos7+CPzGB3g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.4.tgz",
+      "integrity": "sha512-XnWYMI7euHlb5a871xPja+Gm7DRCFU+FGRrtS2sMq9N8FvqtpagUy6gD4YOemC5MRk9xbh8+jYMEJbigFQwsgA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.4.tgz",
+      "integrity": "sha512-qGDAlO0U8xedCcsdRm9oaoQY8DAx/QT7uIxJWhCdx0ceIWX783UC9QSYkdpzAe29wNiVfp24+bZdQmn49o45SQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.4.tgz",
+      "integrity": "sha512-ru4H6ezD7ysA5EiEK6qkkaEb4modH8CTej6kUy/gQi20u3kB3G7Zn8snXXkeJSCOFKG/rbPPtM/+9Wgas1961w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.4.tgz",
+      "integrity": "sha512-2W4MO5WQVJnbJaZdvDb9rhBDuFU1nKIepPFpJUBsTh2k1YY2g+ODViaWuyOAjQ5cOP7NvrvLzt3wvHOoiAvc7w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.4.tgz",
+      "integrity": "sha512-+fxjfuoAmVMCYV5QyjoIpu0cp5DOiOTeqYFk1AVaxGr+/ravWLX89XfQmptsoWcaVy/TGf2hexzbUOrCQIL1CQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.4.tgz",
+      "integrity": "sha512-jTn8JfHGL4djjFxPuM06LmNUJDsst2jeVlsd9OmIH6zc5sC9K6rIuO4YajXatLUpBmBKl6b35ro1QZocLi+tcA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.4.tgz",
+      "integrity": "sha512-oCJCJL4pXsoDcP2QZ+JVlPTIRc6266zsIaeJJsWImmF7HO0W8nb6HuSgZlMWxJwaPf8ehbSw8yo0EUw925hKsA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-W69hukhZ3KKNRCaMIEzKvcFye42hh0FE1+YoYaf5+Ikacuftoco6yO/xouz0hc5d5W/s3yBro5jRiuEE/Q5vUw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.4.tgz",
+      "integrity": "sha512-qiXbGG2jkjXhzXpsFZSR2Xpb8DN/UaxYsbb/STbuR/6fpaDgRmmaq1B/LmtF2wQFOFOSsK2jdE0RZ3a0zHn4QA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.4.tgz",
+      "integrity": "sha512-nWeM//hxv8mIo6jD7Hu4o48DVmV9pbV6gsKaWU+4NFyqHoPKwrkRiZGLKUhOBk8qNmDmpwFtPKg80Bo/Tn4xiQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.4.tgz",
+      "integrity": "sha512-s62SQ/vgsRSvMwDkOEfTqfgASF0f26ZNaQuTA6Aok5lrikf89yI2W0gFHvZb2Jpgc6N8JnOKZgCK2iciO3CsxQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.4.tgz",
+      "integrity": "sha512-J6wGf8TVGbXJq+HH+ttTvrcfNKPbuZecV6KT1B8I18BC5IURUh5kl4Yl5OEP5eFIUoI5BWxCsyYMhFsDx8kekw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.4.tgz",
+      "integrity": "sha512-zmfrQd/0wu6oJs8Vq8KwY/YtsKSsLtKe/HwAP4Wqy8LhWjeT55fHRAkOhYQ12wI3ayS4Tt12d5CDRD7N96SAYQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.4.tgz",
+      "integrity": "sha512-qPzHqdj9rfUD+w79dtE07zi/kFwKyCJqplp5K5ygeLTp7jLpAoc16OAH39HSmRC9UpozaecsleI8uAdEj6v2yw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.4.tgz",
+      "integrity": "sha512-zD6NdeWEByGE9QF9vCrlJ5YQB4oq9q91kPZS37Jwj5hOkvR1lTBSpsKhKDw4IJtbQ35LsTS1HD9DZYGKIshU1Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/dom-mediacapture-record": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/@types/dom-mediacapture-record/-/dom-mediacapture-record-1.0.22.tgz",
+      "integrity": "sha512-mUMZLK3NvwRLcAAT9qmcK+9p7tpU2FHdDsntR3YI4+GY88XrgG4XiE7u1Q2LAN2/FZOz/tdMDC3GQCR4T8nFuw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.18",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.18.tgz",
+      "integrity": "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.2.4",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.4.tgz",
+      "integrity": "sha512-Bsc+QHgp+P/F02XDzNCY9jnZNCUuLki36KT7VKrTXXLdHf+vHMNZnW1rVu5DNW/rCK+fya3DATySbLM4yhtKUw==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.2.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.7.tgz",
+      "integrity": "sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.7.tgz",
+      "integrity": "sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.7.tgz",
+      "integrity": "sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.7.tgz",
+      "integrity": "sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.7",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.7.tgz",
+      "integrity": "sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.7.tgz",
+      "integrity": "sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.7.tgz",
+      "integrity": "sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.7",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.11.13",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.13.tgz",
+      "integrity": "sha512-k9HNuUVMlqVjQ9UHzfPjIqiDbWw7WqT1AoT7GL8VwvF3r0ZfArtgiSPAlmupyNquNgOJHTuH4CKYf8ttMTWBTQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/chess.js": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/chess.js/-/chess.js-1.4.0.tgz",
+      "integrity": "sha512-BBJgrrtKQOzFLonR0l+k64A98NLemPwNsCskwb+29bRwobUa4iTm51E1kwGPbWXAcfdDa18nad6vpPPKPWarqw==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cosmo-ai": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/cosmo-ai/-/cosmo-ai-0.3.0.tgz",
+      "integrity": "sha512-+M2QkUVndkvp2Ji0LW5YkErVLmqHjxae+oNGn3uLbe3/bnh/HfIR4kqvFigGu+ZwqrTNY7cXah+p/LvGekWXQg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "livekit-client": "^2",
+        "react": "^19",
+        "react-dom": "^19",
+        "zod": "^4.2.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.405",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.405.tgz",
+      "integrity": "sha512-bNglH7lPH5l+yHOes7Zr4VqxhOy4BQ9ZBUX4VdoFgxMpzJk7W1ZoO3Vgd9Pxa9PyjQ76sfm2aKH/nzEcCNRlew==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.2.8",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
+      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/livekit-client": {
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/livekit-client/-/livekit-client-2.21.0.tgz",
+      "integrity": "sha512-RBUhPkV/sl1nzl8lokVlK5uATPwn0AlsudCBZXissw/kDl9yz8ac4pNJ43iPpMVoHOeBYH/BZ3vUC1adqa/zFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@livekit/mutex": "1.1.1",
+        "@livekit/protocol": "1.50.4",
+        "events": "^3.3.0",
+        "jose": "^6.1.0",
+        "loglevel": "^1.9.2",
+        "sdp-transform": "^2.15.0",
+        "tslib": "2.8.1",
+        "typed-emitter": "^2.1.0",
+        "webrtc-adapter": "9.0.6"
+      },
+      "peerDependencies": {
+        "@types/dom-mediacapture-record": "^1"
+      }
+    },
+    "node_modules/loglevel": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.9.2.tgz",
+      "integrity": "sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.17",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.8.tgz",
+      "integrity": "sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.2.8",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz",
+      "integrity": "sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.27.0"
+      },
+      "peerDependencies": {
+        "react": "^19.2.8"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.62.4",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.4.tgz",
+      "integrity": "sha512-RXOqwaPsBGjMNMa4sQjDjHieHEZDFoj/Rdr46l2MU5DfEs16wHJPC2RPTPHWhNl+M3aI472LLqFkFKut4SblOg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@napi-rs/lzma-linux-x64-gnu": "1.5.1",
+        "@rollup/rollup-android-arm-eabi": "4.62.4",
+        "@rollup/rollup-android-arm64": "4.62.4",
+        "@rollup/rollup-darwin-arm64": "4.62.4",
+        "@rollup/rollup-darwin-x64": "4.62.4",
+        "@rollup/rollup-freebsd-arm64": "4.62.4",
+        "@rollup/rollup-freebsd-x64": "4.62.4",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.4",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.4",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.4",
+        "@rollup/rollup-linux-arm64-musl": "4.62.4",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.4",
+        "@rollup/rollup-linux-loong64-musl": "4.62.4",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.4",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.4",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.4",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.4",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-gnu": "4.62.4",
+        "@rollup/rollup-linux-x64-musl": "4.62.4",
+        "@rollup/rollup-openbsd-x64": "4.62.4",
+        "@rollup/rollup-openharmony-arm64": "4.62.4",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.4",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.4",
+        "@rollup/rollup-win32-x64-gnu": "4.62.4",
+        "@rollup/rollup-win32-x64-msvc": "4.62.4",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
+    },
+    "node_modules/sdp": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/sdp/-/sdp-3.2.2.tgz",
+      "integrity": "sha512-xZocWwfyp4hkbN4hLWxMjmv2Q8aNa9MhmOZ7L9aCZPT+dZsgRr6wZRrSYE3HTdyk/2pZKPSgqI7ns7Een1xMSA==",
+      "license": "MIT"
+    },
+    "node_modules/sdp-transform": {
+      "version": "2.15.0",
+      "resolved": "https://registry.npmjs.org/sdp-transform/-/sdp-transform-2.15.0.tgz",
+      "integrity": "sha512-KrOH82c/W+GYQ0LHqtr3caRpM3ITglq3ljGUIb8LTki7ByacJZ9z+piSGiwZDsRyhQbYBOBJgr2k6X4BZXi3Kw==",
+      "license": "MIT",
+      "bin": {
+        "sdp-verify": "checker.js"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/typed-emitter/-/typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-g/KzbYKbH5C2vPkaXGu8DJlHrGKHLsM25Zg9WuC9pMGfuvT+X25tZQWo5fK1BjBm8+UrVE9LDCvaY0CQk+fXDA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "rxjs": "*"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.7.tgz",
+      "integrity": "sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.7",
+        "@vitest/mocker": "3.2.7",
+        "@vitest/pretty-format": "^3.2.7",
+        "@vitest/runner": "3.2.7",
+        "@vitest/snapshot": "3.2.7",
+        "@vitest/spy": "3.2.7",
+        "@vitest/utils": "3.2.7",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.7",
+        "@vitest/ui": "3.2.7",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/webrtc-adapter": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/webrtc-adapter/-/webrtc-adapter-9.0.6.tgz",
+      "integrity": "sha512-CHbl2ZQbxx164IgWRgzJno4hWtM4tFbRam1QfI3Yxhs3w/DvqluVxVWeXs3oL5/fbGkSNLKo0Ty5MgUWceNhog==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "sdp": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=6.0.0",
+        "npm": ">=3.10.0"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/examples/typescript/chess-referee/package-lock.json
+++ b/examples/typescript/chess-referee/package-lock.json
@@ -7,12 +7,14 @@
     "": {
       "name": "cosmo-chess-referee",
       "version": "0.1.0",
+      "hasInstallScript": true,
       "dependencies": {
         "chess.js": "^1.4.0",
         "cosmo-ai": "^0.3.0",
         "livekit-client": "^2",
         "react": "^19",
         "react-dom": "^19",
+        "stockfish": "^18.0.8",
         "zod": "^4.4.3"
       },
       "devDependencies": {
@@ -2042,6 +2044,16 @@
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/stockfish": {
+      "version": "18.0.8",
+      "resolved": "https://registry.npmjs.org/stockfish/-/stockfish-18.0.8.tgz",
+      "integrity": "sha512-z+f2UMPXLylDBGjv9e9zU8QulY7hUl8MYHesLRrdddewlOXjJrUSmtNmbtID1/F72EPhq0CCkCNxgWS5MQVWtQ==",
+      "hasInstallScript": true,
+      "license": "GPL-3.0",
+      "bin": {
+        "stockfish": "scripts/cli.js"
+      }
     },
     "node_modules/strip-literal": {
       "version": "3.1.0",

--- a/examples/typescript/chess-referee/package.json
+++ b/examples/typescript/chess-referee/package.json
@@ -8,10 +8,12 @@
     "build": "vite build",
     "typecheck": "tsc --noEmit",
     "test": "vitest run",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "postinstall": "node scripts/copy_stockfish.mjs"
   },
   "dependencies": {
     "chess.js": "^1.4.0",
+    "stockfish": "^18.0.8",
     "cosmo-ai": "^0.3.0",
     "livekit-client": "^2",
     "react": "^19",

--- a/examples/typescript/chess-referee/package.json
+++ b/examples/typescript/chess-referee/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "cosmo-chess-referee",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "chess.js": "^1.4.0",
+    "cosmo-ai": "^0.3.0",
+    "livekit-client": "^2",
+    "react": "^19",
+    "react-dom": "^19",
+    "zod": "^4.4.3"
+  },
+  "devDependencies": {
+    "@types/react": "^19",
+    "@types/react-dom": "^19",
+    "@vitejs/plugin-react": "^4",
+    "typescript": "^5",
+    "vite": "^5",
+    "vitest": "^3"
+  }
+}

--- a/examples/typescript/chess-referee/scripts/copy_stockfish.mjs
+++ b/examples/typescript/chess-referee/scripts/copy_stockfish.mjs
@@ -1,0 +1,26 @@
+/**
+ * Copies the single-threaded lite Stockfish build into public/ so Vite
+ * serves it as-is: the engine .js runs directly as a web worker and fetches
+ * its .wasm relative to its own URL, which bundling would break.
+ */
+
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const bin = join(
+  dirname(createRequire(import.meta.url).resolve('stockfish/package.json')),
+  'bin',
+);
+const out = join(here, '..', 'public', 'stockfish');
+
+mkdirSync(out, { recursive: true });
+for (const file of [
+  'stockfish-18-lite-single.js',
+  'stockfish-18-lite-single.wasm',
+]) {
+  copyFileSync(join(bin, file), join(out, file));
+}
+console.log(`copied stockfish lite-single to ${out}`);

--- a/examples/typescript/chess-referee/src/App.tsx
+++ b/examples/typescript/chess-referee/src/App.tsx
@@ -1,0 +1,341 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  CosmoRealtimeProvider,
+  MicToggle,
+  RealtimeAudio,
+  RealtimeClient,
+  useTranscript,
+  useTransportState,
+} from 'cosmo-ai';
+
+import type { BoardOrientation } from './board_vision';
+import { FrameCapture } from './frame_capture';
+import { REFEREE_ALERT_TAG, REFEREE_INSTRUCTIONS } from './instructions';
+import { Referee, type RefereeEvent } from './referee';
+import { startRefereeLoop } from './referee_loop';
+import { makeBoardPositionTool } from './tools';
+
+// Prefill from a gitignored .env for local dev convenience (see .env.example).
+// Never hardcode a key here — this file is committed.
+const BASE_URL_DEFAULT = import.meta.env.VITE_COSMO_BASE_URL ?? 'https://platform.askcosmo.ai';
+const API_KEY_DEFAULT = import.meta.env.VITE_COSMO_API_KEY ?? '';
+
+/** Name the backend from inside the page. The SDK reads ``COSMO_BASE_URL``
+ *  on Node; a browser has no environment, so it reads this tag instead —
+ *  normally written by the server that rendered the page. */
+function setCosmoBaseUrl(baseUrl: string): void {
+  let tag = document.querySelector('meta[name="cosmo-base-url"]');
+  if (tag === null) {
+    tag = document.createElement('meta');
+    tag.setAttribute('name', 'cosmo-base-url');
+    document.head.appendChild(tag);
+  }
+  tag.setAttribute('content', baseUrl);
+}
+
+type BoardSource = 'camera' | 'screen';
+
+async function openBoardStream(source: BoardSource): Promise<MediaStream> {
+  if (source === 'screen') {
+    return navigator.mediaDevices.getDisplayMedia({ video: true });
+  }
+  return navigator.mediaDevices.getUserMedia({
+    video: {
+      facingMode: 'environment',
+      width: { ideal: 1920 },
+      height: { ideal: 1080 },
+    },
+  });
+}
+
+function describeVerdict(event: RefereeEvent): string {
+  switch (event.kind) {
+    case 'game_started':
+      return 'Game on — starting position recognized';
+    case 'legal_move':
+      return `${event.mover} played ${event.san}`;
+    case 'illegal_move':
+      return `ILLEGAL: ${event.description}`;
+    case 'out_of_turn':
+      return `Out of turn: ${event.mover} played ${event.san}`;
+    case 'board_scrambled':
+      return 'Board unclear — waiting for a clean position';
+  }
+}
+
+/** Forward a referee event into the session: silent context for normal play,
+ *  a spoken interjection for violations. */
+function forward(client: RealtimeClient, event: RefereeEvent): void {
+  switch (event.kind) {
+    case 'game_started':
+      void client.sendContext('[board] New game from the starting position. White to move.');
+      break;
+    case 'legal_move':
+      void client.sendContext(
+        `[board] ${event.mover} played ${event.san}. Position (FEN): ${event.fen}`,
+      );
+      break;
+    case 'illegal_move':
+      void client.sendText(
+        `${REFEREE_ALERT_TAG} Illegal move on the board: ${event.description}. ` +
+          `Observed placement: ${event.observed}. Call it out now.`,
+        { transcript: false },
+      );
+      break;
+    case 'out_of_turn':
+      void client.sendText(
+        `${REFEREE_ALERT_TAG} ${event.mover} just played ${event.san} — but it is not ` +
+          `${event.mover}'s turn. Call it out now.`,
+        { transcript: false },
+      );
+      break;
+    case 'board_scrambled':
+      void client.sendContext(
+        '[board] The board changed in a way no single move explains ' +
+          '(pieces knocked over or mid-adjustment). Waiting for it to settle.',
+      );
+      break;
+  }
+}
+
+function SessionView({
+  stream,
+  verdict,
+  readError,
+  onEnd,
+}: {
+  stream: MediaStream;
+  verdict: string;
+  readError: string | null;
+  onEnd: () => void;
+}) {
+  const transport = useTransportState();
+  const transcript = useTranscript();
+  const videoRef = useRef<HTMLVideoElement>(null);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const el = videoRef.current;
+    if (el) el.srcObject = stream;
+  }, [stream]);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (el) el.scrollTop = el.scrollHeight;
+  }, [transcript]);
+
+  const live = transport === 'ready' || transport === 'connected';
+  const bad = transport === 'failed' || transport === 'disconnected';
+
+  return (
+    <>
+      <div className="session-bar">
+        <span className={`status${live ? ' live' : bad ? ' bad' : ''}`}>
+          <span className="status-dot" />
+          {live ? 'Watching' : bad ? 'Not connected' : transport}
+        </span>
+        <MicToggle />
+        <button className="btn btn-ghost" onClick={onEnd}>
+          End session
+        </button>
+      </div>
+
+      <RealtimeAudio />
+
+      <div className="session-grid">
+        <div className="stage-col">
+          <video ref={videoRef} autoPlay muted playsInline />
+          <div className={`verdict${verdict.startsWith('ILLEGAL') ? ' bad' : ''}`}>
+            {verdict || 'Set up the starting position to begin'}
+          </div>
+          {readError && <div className="err">{readError}</div>}
+        </div>
+
+        <div className="chat-col">
+          <p className="chat-head">Conversation</p>
+          <div className="transcript scroll" ref={scrollRef}>
+            {transcript.length === 0 ? (
+              <p className="empty">Say hello, or ask what the referee can see.</p>
+            ) : (
+              transcript.map((item) => (
+                <div
+                  key={item.id}
+                  className={`bubble ${item.role === 'user' ? 'user' : 'assistant'}${item.isFinal ? '' : ' partial'}`}
+                >
+                  {item.text}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function App() {
+  const [apiKey, setApiKey] = useState(API_KEY_DEFAULT);
+  const [baseUrl, setBaseUrl] = useState(BASE_URL_DEFAULT);
+  const [source, setSource] = useState<BoardSource>('camera');
+  const [orientation, setOrientation] = useState<BoardOrientation | 'auto'>('white');
+  const [connecting, setConnecting] = useState(false);
+  const [startError, setStartError] = useState<string | null>(null);
+  const [verdict, setVerdict] = useState('');
+  const [readError, setReadError] = useState<string | null>(null);
+
+  const clientRef = useRef<RealtimeClient | null>(null);
+  const captureRef = useRef<FrameCapture | null>(null);
+  const stopLoopRef = useRef<(() => void) | null>(null);
+  const [stream, setStream] = useState<MediaStream | null>(null);
+
+  const teardown = useCallback(() => {
+    stopLoopRef.current?.();
+    stopLoopRef.current = null;
+    void clientRef.current?.disconnect();
+    clientRef.current = null;
+    captureRef.current?.dispose();
+    captureRef.current = null;
+    setStream(null);
+    setVerdict('');
+    setReadError(null);
+  }, []);
+
+  useEffect(() => teardown, [teardown]);
+
+  const handleStart = useCallback(async () => {
+    if (!apiKey) return;
+    setConnecting(true);
+    setStartError(null);
+    setCosmoBaseUrl(baseUrl);
+
+    const pinned = orientation === 'auto' ? undefined : orientation;
+    const vision = { baseUrl, apiKey };
+    const referee = new Referee();
+    let capture: FrameCapture | null = null;
+    const client = new RealtimeClient({ apiKey });
+    try {
+      capture = new FrameCapture(await openBoardStream(source));
+      await client
+        .agent({
+          instructions: REFEREE_INSTRUCTIONS,
+          tools: [
+            makeBoardPositionTool({
+              vision,
+              getCapture: () => captureRef.current,
+              referee,
+              orientation: pinned,
+            }),
+          ],
+          greeting:
+            "Hi, I'm your referee — set the pieces up in the starting position and I'll follow along.",
+        })
+        .start();
+
+      captureRef.current = capture;
+      clientRef.current = client;
+      setStream(capture.stream);
+      stopLoopRef.current = startRefereeLoop({
+        capture,
+        vision,
+        referee,
+        orientation: pinned,
+        onEvent: (event) => {
+          setVerdict(describeVerdict(event));
+          setReadError(null);
+          forward(client, event);
+        },
+        onReadError: (error) => {
+          setReadError(error instanceof Error ? error.message : String(error));
+        },
+      });
+    } catch (err) {
+      capture?.dispose();
+      void client.disconnect();
+      setStartError(
+        err instanceof Error && /401|invalid/i.test(err.message)
+          ? 'That key was rejected. Check it matches the server below — a key from one environment will not work against another.'
+          : err instanceof Error
+            ? err.message
+            : String(err),
+      );
+    } finally {
+      setConnecting(false);
+    }
+  }, [apiKey, baseUrl, source, orientation]);
+
+  const client = clientRef.current;
+
+  return (
+    <div className={`shell${client && stream ? ' wide' : ''}`}>
+      <header className="masthead">
+        <p className="eyebrow">Cosmo Realtime</p>
+        <h1>Chess referee</h1>
+        <p className="lede">
+          Point a camera at your board. The referee follows every move — and speaks up,
+          unprompted, when someone breaks the rules.
+        </p>
+      </header>
+
+      {client && stream ? (
+        <CosmoRealtimeProvider client={client} maxTranscriptLength={50}>
+          <SessionView stream={stream} verdict={verdict} readError={readError} onEnd={teardown} />
+        </CosmoRealtimeProvider>
+      ) : (
+        <>
+          <div className="field-row">
+            <div className="field">
+              <label htmlFor="src">Board source</label>
+              <select
+                id="src"
+                value={source}
+                onChange={(e) => setSource(e.target.value as BoardSource)}
+              >
+                <option value="camera">Camera</option>
+                <option value="screen">Screen share (lichess, chess.com)</option>
+              </select>
+            </div>
+            <div className="field">
+              <label htmlFor="or">Side nearest the camera</label>
+              <select
+                id="or"
+                value={orientation}
+                onChange={(e) => setOrientation(e.target.value as BoardOrientation | 'auto')}
+              >
+                <option value="white">White</option>
+                <option value="black">Black</option>
+                <option value="auto">Detect from the board</option>
+              </select>
+            </div>
+          </div>
+
+          <button
+            className="btn btn-primary"
+            onClick={() => void handleStart()}
+            disabled={connecting || !apiKey}
+          >
+            {connecting ? 'Connecting…' : apiKey ? 'Start refereeing' : 'Add a key below to start'}
+          </button>
+          {startError && <div className="err">{startError}</div>}
+
+          <details className="settings" open={!apiKey}>
+            <summary>Connection</summary>
+            <div className="field">
+              <label htmlFor="k">API key</label>
+              <input
+                id="k"
+                type="password"
+                value={apiKey}
+                onChange={(e) => setApiKey(e.target.value)}
+                placeholder="cosmo_…"
+              />
+            </div>
+            <div className="field">
+              <label htmlFor="u">Server</label>
+              <input id="u" value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} />
+            </div>
+          </details>
+        </>
+      )}
+    </div>
+  );
+}

--- a/examples/typescript/chess-referee/src/App.tsx
+++ b/examples/typescript/chess-referee/src/App.tsx
@@ -13,6 +13,11 @@ import { FrameCapture } from './frame_capture';
 import { REFEREE_ALERT_TAG, REFEREE_INSTRUCTIONS } from './instructions';
 import { Referee, type RefereeEvent } from './referee';
 import { startRefereeLoop } from './referee_loop';
+import { makeAnalyzePositionTool } from './analysis/analyze_position';
+import {
+  disposeAnalysisEngine,
+  warmAnalysisEngine,
+} from './analysis/stockfish_transport';
 import { makeBoardPositionTool } from './tools';
 
 // Prefill from a gitignored .env for local dev convenience (see .env.example).
@@ -195,6 +200,7 @@ export function App() {
     clientRef.current = null;
     captureRef.current?.dispose();
     captureRef.current = null;
+    disposeAnalysisEngine();
     setStream(null);
     setVerdict('');
     setReadError(null);
@@ -215,6 +221,7 @@ export function App() {
     const client = new RealtimeClient({ apiKey });
     try {
       capture = new FrameCapture(await openBoardStream(source));
+      warmAnalysisEngine();
       await client
         .agent({
           instructions: REFEREE_INSTRUCTIONS,
@@ -225,6 +232,7 @@ export function App() {
               referee,
               orientation: pinned,
             }),
+            makeAnalyzePositionTool(),
           ],
           greeting:
             "Hi, I'm your referee — set the pieces up in the starting position and I'll follow along.",

--- a/examples/typescript/chess-referee/src/analysis/analyze.integration.test.ts
+++ b/examples/typescript/chess-referee/src/analysis/analyze.integration.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Runs the real single-threaded lite wasm engine through the same UciEngine
+ * client the browser uses; only the transport differs (the `stockfish`
+ * package's Node loader instead of a Worker).
+ *
+ * One engine for the whole file: the Node loader's emscripten state is
+ * per-process and a second init aborts, which also matches how the app
+ * holds one engine per session.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { UciEngine, type UciTransport } from './engine';
+import { analyzePosition } from './analyze_core';
+
+async function createNodeTransport(): Promise<UciTransport> {
+  const initEngine = (await import('stockfish')).default;
+  const engine = await initEngine('lite-single');
+  const listeners: Array<(line: string) => void> = [];
+  engine.listener = (line: string) => {
+    for (const listener of listeners) listener(line);
+  };
+  return {
+    send: (command) => engine.sendCommand(command),
+    onLine: (listener) => listeners.push(listener),
+    // The Node loader turns `quit` into process.exit(), which would kill the
+    // test process; the fork's teardown reaps the wasm instance instead.
+    terminate: () => {},
+  };
+}
+
+let engine: UciEngine;
+
+beforeAll(async () => {
+  engine = new UciEngine(await createNodeTransport());
+}, 60_000);
+
+afterAll(() => {
+  engine.close();
+});
+
+describe('analyzePosition against real Stockfish', () => {
+  it('finds mate in one', { timeout: 60_000 }, async () => {
+    // Back-rank mate: Re8#.
+    const result = await analyzePosition(
+      engine,
+      '6k1/5ppp/8/8/8/8/5PPP/4R1K1',
+      'white',
+    );
+    expect(result.status).toBe('ok');
+    expect(result.top_moves?.[0]?.move).toBe('Re8#');
+    expect(result.top_moves?.[0]?.eval).toBe('mate in 1');
+    expect(result.position_fen).toBe('6k1/5ppp/8/8/8/8/5PPP/4R1K1 w - - 0 1');
+    expect(result.coach_hint).toContain('Re8#');
+  });
+
+  it('returns three ranked moves with lines from the start position', {
+    timeout: 60_000,
+  }, async () => {
+    const result = await analyzePosition(
+      engine,
+      'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR',
+      'white',
+    );
+    expect(result.status).toBe('ok');
+    expect(result.top_moves).toHaveLength(3);
+    for (const move of result.top_moves ?? []) {
+      expect(move.line[0]).toBe(move.move);
+      expect(move.eval).toMatch(/^[+-]\d+\.\d{2}$/);
+    }
+    expect(result.side_to_move).toBe('white');
+  });
+
+  it('rejects an illegal placement without touching the engine', async () => {
+    const result = await analyzePosition(
+      engine,
+      'rnbq1bnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR',
+      'white',
+    );
+    expect(result.status).toBe('unreadable');
+    expect(result.coach_hint).toContain('get_chess_board_position');
+  });
+
+  it('serializes concurrent calls on one engine', { timeout: 60_000 }, async () => {
+    const [a, b] = await Promise.all([
+      analyzePosition(engine, '6k1/5ppp/8/8/8/8/5PPP/4R1K1', 'white'),
+      analyzePosition(
+        engine,
+        'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR',
+        'black',
+      ),
+    ]);
+    expect(a.top_moves?.[0]?.move).toBe('Re8#');
+    expect(b.status).toBe('ok');
+    expect(b.top_moves?.length).toBeGreaterThan(0);
+  });
+});

--- a/examples/typescript/chess-referee/src/analysis/analyze_core.ts
+++ b/examples/typescript/chess-referee/src/analysis/analyze_core.ts
@@ -1,0 +1,90 @@
+/**
+ * Client-side position analysis: Stockfish runs in a web worker on the
+ * user's machine, no backend round-trip. The result mirrors the Cosmo
+ * backend's `start_chess_analysis` tool so agent instructions written
+ * against either work unchanged.
+ */
+
+import { EngineError, UciEngine } from './engine';
+import {
+  annotateMoves,
+  describeInvalidity,
+  formatEval,
+  fullFen,
+  pvToSan,
+  type SideToMove,
+  type TopMove,
+} from './position';
+
+/**
+ * Coaching wants bounded latency, not a fixed depth (which can spike past a
+ * second on sharp positions). Single-threaded lite wasm reaches the ~depth
+ * 12–15 a coach needs well inside this budget.
+ */
+const MOVETIME_MS = 750;
+const TOP_N = 3;
+
+export type AnalyzePositionResult = {
+  status: 'ok' | 'unreadable' | 'error';
+  side_to_move?: SideToMove;
+  top_moves?: TopMove[];
+  coach_hint: string;
+  position_fen?: string;
+};
+
+export async function analyzePosition(
+  engine: UciEngine,
+  position: string,
+  sideToMove: SideToMove,
+): Promise<AnalyzePositionResult> {
+  // The placement came from get_chess_board_position, but it arrives back
+  // through the model, so it is untrusted input: validate before handing it
+  // to the engine.
+  const fen = fullFen(position, sideToMove);
+  const flaw = describeInvalidity(fen);
+  if (flaw !== null) {
+    console.warn('analyze_position: invalid position', { flaw });
+    return {
+      status: 'unreadable',
+      coach_hint:
+        "That position isn't legal — call get_chess_board_position again and " +
+        'pass its placement through unchanged.',
+    };
+  }
+
+  let engineLines;
+  try {
+    engineLines = await engine.analyze(fen, MOVETIME_MS);
+  } catch (error) {
+    console.error('analyze_position: engine failed', error);
+    return {
+      status: 'error',
+      coach_hint:
+        error instanceof EngineError
+          ? 'My chess engine is unavailable — coach from general principles for now.'
+          : 'I had trouble analyzing — coach from general principles for now.',
+    };
+  }
+
+  const topMoves: TopMove[] = [];
+  for (const line of engineLines.slice(0, TOP_N)) {
+    const san = pvToSan(fen, line.pv);
+    if (san.length === 0) continue;
+    topMoves.push({
+      rank: topMoves.length + 1,
+      move: san[0],
+      eval: formatEval(line.scoreCp, line.mateIn),
+      line: san,
+    });
+  }
+  return {
+    status: 'ok',
+    side_to_move: sideToMove,
+    top_moves: topMoves,
+    coach_hint: annotateMoves(fen, topMoves),
+    // The full FEN tells the model what is actually on each square (e.g.
+    // which piece a capturing move wins) instead of it guessing from its own
+    // reading of the screen.
+    position_fen: fen,
+  };
+}

--- a/examples/typescript/chess-referee/src/analysis/analyze_position.test.ts
+++ b/examples/typescript/chess-referee/src/analysis/analyze_position.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { makeAnalyzePositionTool } from './analyze_position';
+import type { UciEngine } from './engine';
+
+describe('makeAnalyzePositionTool', () => {
+  // tool() validates the name and emitted JSON Schema against the backend's
+  // restricted dialect at construction, so this pins "the server would
+  // accept this tool" without a session.
+  it('constructs a client tool spec the server accepts', () => {
+    const spec = makeAnalyzePositionTool(() => {
+      throw new Error('engine must not start at construction time');
+    });
+    expect(spec.kind).toBe('client');
+    expect(spec.name).toBe('analyze_position');
+    expect(spec.parameters).toMatchObject({
+      type: 'object',
+      required: ['position', 'side_to_move'],
+    });
+  });
+
+  it('rejects a malformed model call before the engine is touched', async () => {
+    const spec = makeAnalyzePositionTool(() => {
+      throw new Error('engine must not start on invalid input');
+    });
+    await expect(
+      spec.handler!({ position: 'x', side_to_move: 'purple' }),
+    ).rejects.toThrow();
+  });
+
+  it('runs the handler against a stubbed engine', async () => {
+    const engine = {
+      analyze: async () => [
+        { multipv: 1, depth: 12, scoreCp: 45, mateIn: null, pv: ['e2e4', 'e7e5'] },
+      ],
+    } as unknown as UciEngine;
+    const result = (await makeAnalyzePositionTool(() => engine).handler!({
+      position: 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR',
+      side_to_move: 'white',
+    })) as Record<string, unknown>;
+    expect(result.status).toBe('ok');
+    expect(result.top_moves).toEqual([
+      { rank: 1, move: 'e4', eval: '+0.45', line: ['e4', 'e5'] },
+    ]);
+  });
+});

--- a/examples/typescript/chess-referee/src/analysis/analyze_position.ts
+++ b/examples/typescript/chess-referee/src/analysis/analyze_position.ts
@@ -1,0 +1,44 @@
+/**
+ * `analyze_position` — a pure client tool over {@link analyzePosition}: FEN
+ * placement in (passed through from `get_chess_board_position`, never
+ * model-authored), top moves with eval and expected line out. Stockfish runs
+ * in a web worker on this machine; no backend round-trip.
+ */
+
+import { tool } from 'cosmo-ai/tool';
+import { zodInput } from 'cosmo-ai/tool/zod';
+import { z } from 'zod/v4';
+
+import { analyzePosition } from './analyze_core';
+import type { UciEngine } from './engine';
+import { analysisEngine } from './stockfish_transport';
+
+export function makeAnalyzePositionTool(getEngine: () => UciEngine = analysisEngine) {
+  return tool({
+    name: 'analyze_position',
+    description:
+      "Get the chess engine's strongest moves for a position you already read " +
+      'with get_chess_board_position. Pass that placement through unchanged, ' +
+      'plus whose turn it is — side_to_move is the player ON MOVE, not the ' +
+      'colour the user plays. Returns the moves directly. Coach from them ' +
+      'conversationally; never recite raw lines.',
+    input: zodInput(
+      z.object({
+        position: z
+          .string()
+          .describe(
+            'The FEN placement returned by get_chess_board_position, passed ' +
+              'through unchanged. Never write this yourself and never edit it.',
+          ),
+        side_to_move: z
+          .enum(['white', 'black'])
+          .describe(
+            'Whose turn it is in this position — NOT which color the user ' +
+              "plays. If the user just moved it is their opponent's turn.",
+          ),
+      }),
+    ),
+    handler: async ({ position, side_to_move }) =>
+      analyzePosition(getEngine(), position, side_to_move),
+  });
+}

--- a/examples/typescript/chess-referee/src/analysis/engine.ts
+++ b/examples/typescript/chess-referee/src/analysis/engine.ts
@@ -1,0 +1,157 @@
+/**
+ * Minimal UCI client for a Stockfish wasm engine.
+ *
+ * The transport is one message-port-shaped seam (`send` strings in, lines
+ * out) so the same client drives a browser `Worker` in the app and the
+ * `stockfish` package's Node loader in tests.
+ */
+
+export interface UciTransport {
+  send(command: string): void;
+  onLine(listener: (line: string) => void): void;
+  terminate(): void;
+}
+
+export type EngineLine = {
+  multipv: number;
+  depth: number;
+  /** Centipawns from the side-to-move's point of view; mate folded in. */
+  scoreCp: number;
+  /** Signed moves-to-mate from the side to move, when the line ends in mate. */
+  mateIn: number | null;
+  /** Principal variation as UCI moves, e.g. ["e2e4", "e7e5"]. */
+  pv: string[];
+};
+
+/** Mirrors the backend's MATE_SCORE so mate lines outrank any cp eval. */
+export const MATE_SCORE = 100_000;
+
+const READY_TIMEOUT_MS = 20_000;
+const SEARCH_GRACE_MS = 5_000;
+
+export class EngineError extends Error {}
+
+export class UciEngine {
+  private transport: UciTransport;
+  /** Search is not concurrency-safe; calls queue behind this chain. */
+  private chain: Promise<unknown> = Promise.resolve();
+  private listeners = new Set<(line: string) => void>();
+  private ready: Promise<void>;
+
+  constructor(transport: UciTransport, options?: { multiPv?: number }) {
+    this.transport = transport;
+    transport.onLine((line) => {
+      for (const listener of this.listeners) listener(line);
+    });
+    this.ready = this.handshake(options?.multiPv ?? 3);
+  }
+
+  private async handshake(multiPv: number): Promise<void> {
+    const uciok = this.waitFor((line) => line === 'uciok', READY_TIMEOUT_MS);
+    this.transport.send('uci');
+    await uciok;
+    this.transport.send(`setoption name MultiPV value ${multiPv}`);
+    const readyok = this.waitFor((line) => line === 'readyok', READY_TIMEOUT_MS);
+    this.transport.send('isready');
+    await readyok;
+  }
+
+  /** Resolves with the first line matching `match`; rejects after `timeoutMs`. */
+  private waitFor(
+    match: (line: string) => boolean,
+    timeoutMs: number,
+  ): Promise<string> {
+    return new Promise((resolve, reject) => {
+      const listener = (line: string) => {
+        if (!match(line)) return;
+        cleanup();
+        resolve(line);
+      };
+      const timer = setTimeout(() => {
+        cleanup();
+        reject(new EngineError(`engine did not respond within ${timeoutMs}ms`));
+      }, timeoutMs);
+      const cleanup = () => {
+        clearTimeout(timer);
+        this.listeners.delete(listener);
+      };
+      this.listeners.add(listener);
+    });
+  }
+
+  /**
+   * Top-`multiPv` lines for a full FEN, bounded by `movetimeMs`.
+   *
+   * Only the final depth's `info` lines are kept: the engine restates every
+   * multipv rank each iteration, so lines from earlier, shallower iterations
+   * are superseded.
+   */
+  analyze(fen: string, movetimeMs: number): Promise<EngineLine[]> {
+    const run = this.chain.then(async () => {
+      await this.ready;
+      const lines = new Map<number, EngineLine>();
+      const collector = (line: string) => {
+        const parsed = parseInfoLine(line);
+        if (parsed) lines.set(parsed.multipv, parsed);
+      };
+      this.listeners.add(collector);
+      try {
+        const done = this.waitFor(
+          (line) => line.startsWith('bestmove'),
+          movetimeMs + SEARCH_GRACE_MS,
+        );
+        this.transport.send('ucinewgame');
+        this.transport.send(`position fen ${fen}`);
+        this.transport.send(`go movetime ${movetimeMs}`);
+        await done;
+      } finally {
+        this.listeners.delete(collector);
+      }
+      return [...lines.values()].sort((a, b) => a.multipv - b.multipv);
+    });
+    // Keep the chain alive past a failed call so the next one still runs.
+    this.chain = run.catch(() => undefined);
+    return run;
+  }
+
+  close(): void {
+    this.transport.terminate();
+  }
+}
+
+/** Parses one `info ... multipv N ... score cp|mate S ... pv ...` line. */
+export function parseInfoLine(line: string): EngineLine | null {
+  if (!line.startsWith('info ') || !line.includes(' pv ')) return null;
+  const tokens = line.split(/\s+/);
+  let multipv = 1;
+  let depth = 0;
+  let scoreCp: number | null = null;
+  let mateIn: number | null = null;
+  let pv: string[] = [];
+  for (let i = 1; i < tokens.length; i++) {
+    switch (tokens[i]) {
+      case 'multipv':
+        multipv = Number(tokens[++i]);
+        break;
+      case 'depth':
+        depth = Number(tokens[++i]);
+        break;
+      case 'score': {
+        const kind = tokens[++i];
+        const value = Number(tokens[++i]);
+        if (kind === 'cp') scoreCp = value;
+        else if (kind === 'mate') {
+          mateIn = value;
+          scoreCp = value > 0 ? MATE_SCORE - value : -MATE_SCORE - value;
+        }
+        break;
+      }
+      case 'pv':
+        pv = tokens.slice(i + 1);
+        i = tokens.length;
+        break;
+    }
+  }
+  if (scoreCp === null || pv.length === 0) return null;
+  return { multipv, depth, scoreCp, mateIn, pv };
+}

--- a/examples/typescript/chess-referee/src/analysis/position.test.ts
+++ b/examples/typescript/chess-referee/src/analysis/position.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseInfoLine, MATE_SCORE } from './engine';
+import {
+  annotateMoves,
+  describeInvalidity,
+  formatEval,
+  fullFen,
+  pvToSan,
+} from './position';
+
+const START = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR';
+
+describe('fullFen', () => {
+  it('appends side to move and neutral counters', () => {
+    expect(fullFen(START, 'white')).toBe(`${START} w - - 0 1`);
+    expect(fullFen(START, 'black')).toBe(`${START} b - - 0 1`);
+  });
+
+  it('keeps only the placement field of a full FEN', () => {
+    expect(fullFen(`${START} w KQkq - 4 12`, 'black')).toBe(`${START} b - - 0 1`);
+  });
+});
+
+describe('describeInvalidity', () => {
+  it('accepts the start position', () => {
+    expect(describeInvalidity(fullFen(START, 'white'))).toBeNull();
+  });
+
+  it('rejects garbage', () => {
+    expect(describeInvalidity('not a fen')).toBeTruthy();
+  });
+
+  it('rejects a missing king', () => {
+    expect(
+      describeInvalidity('rnbq1bnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1'),
+    ).toMatch(/king/);
+  });
+
+  it('rejects a pawn on the back rank', () => {
+    expect(
+      describeInvalidity('Pnbqkbnr/1ppppppp/8/8/8/8/PPPPPPP1/RNBQKBNR w - - 0 1'),
+    ).toMatch(/pawn/);
+  });
+
+  it('rejects too many pawns', () => {
+    expect(
+      describeInvalidity('rnbqkbnr/pppppppp/p7/8/8/8/PPPPPPPP/RNBQKBNR w - - 0 1'),
+    ).toContain('too many black pawns');
+  });
+
+  it('rejects the side NOT to move being in check', () => {
+    // White queen on e7 checks the black king, but it is white to move.
+    expect(
+      describeInvalidity('rnb1kbnr/ppppQppp/8/8/8/8/PPPP1PPP/RNB1KBNR w - - 0 1'),
+    ).toContain('side NOT to move is in check');
+  });
+
+  it('accepts the side to move being in check', () => {
+    expect(
+      describeInvalidity('rnb1kbnr/ppppQppp/8/8/8/8/PPPP1PPP/RNB1KBNR b - - 0 1'),
+    ).toBeNull();
+  });
+});
+
+describe('formatEval', () => {
+  it('renders centipawns as signed pawns', () => {
+    expect(formatEval(45, null)).toBe('+0.45');
+    expect(formatEval(-120, null)).toBe('-1.20');
+    expect(formatEval(0, null)).toBe('+0.00');
+  });
+
+  it('renders mate for and against', () => {
+    expect(formatEval(MATE_SCORE - 2, 2)).toBe('mate in 2');
+    expect(formatEval(-MATE_SCORE + 3, -3)).toBe('mate in 3 (against)');
+  });
+});
+
+describe('pvToSan', () => {
+  it('converts and truncates to four plies', () => {
+    const fen = fullFen(START, 'white');
+    expect(pvToSan(fen, ['e2e4', 'e7e5', 'g1f3', 'b8c6', 'f1b5'])).toEqual([
+      'e4',
+      'e5',
+      'Nf3',
+      'Nc6',
+    ]);
+  });
+
+  it('handles promotion moves', () => {
+    const fen = '8/2P3k1/8/8/8/8/6K1/8 w - - 0 1';
+    expect(pvToSan(fen, ['c7c8q'])).toEqual(['c8=Q']);
+  });
+
+  it('stops at the first unplayable move', () => {
+    const fen = fullFen(START, 'white');
+    expect(pvToSan(fen, ['e2e4', 'e2e4'])).toEqual(['e4']);
+  });
+});
+
+describe('annotateMoves', () => {
+  it('names the captured piece and square', () => {
+    // White to move, black pawn hanging on d5.
+    const fen = 'rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w - - 0 1';
+    const text = annotateMoves(fen, [
+      { rank: 1, move: 'exd5', eval: '+0.50', line: ['exd5', 'Qxd5'] },
+    ]);
+    expect(text).toContain('captures the pawn on d5');
+    expect(text).toContain('expect exd5 Qxd5');
+  });
+
+  it('names en passant captures', () => {
+    const fen = 'rnbqkbnr/ppp1pppp/8/8/3pP3/8/PPPP1PPP/RNBQKBNR b - e3 0 1';
+    const text = annotateMoves(fen, [
+      { rank: 1, move: 'dxe3', eval: '+0.10', line: ['dxe3'] },
+    ]);
+    expect(text).toContain('captures a pawn en passant');
+  });
+});
+
+describe('parseInfoLine', () => {
+  it('parses a cp line', () => {
+    const line =
+      'info depth 15 seldepth 21 multipv 2 score cp 34 nodes 1000 pv e2e4 e7e5';
+    expect(parseInfoLine(line)).toEqual({
+      multipv: 2,
+      depth: 15,
+      scoreCp: 34,
+      mateIn: null,
+      pv: ['e2e4', 'e7e5'],
+    });
+  });
+
+  it('parses a mate line and folds the score', () => {
+    const line = 'info depth 10 multipv 1 score mate -2 pv e2e4';
+    const parsed = parseInfoLine(line);
+    expect(parsed?.mateIn).toBe(-2);
+    expect(parsed?.scoreCp).toBe(-MATE_SCORE + 2);
+  });
+
+  it('ignores lines without a pv', () => {
+    expect(parseInfoLine('info depth 5 currmove e2e4')).toBeNull();
+    expect(parseInfoLine('bestmove e2e4')).toBeNull();
+  });
+});

--- a/examples/typescript/chess-referee/src/analysis/position.ts
+++ b/examples/typescript/chess-referee/src/analysis/position.ts
@@ -1,0 +1,145 @@
+/**
+ * Position legality and coach-facing formatting, mirroring the contract of
+ * the Cosmo backend's `start_chess_analysis` tool: a FEN placement is
+ * untrusted input (it round-trips through the model), so it is validated
+ * before it reaches the engine, and engine output is rendered into the same
+ * speakable shapes (`+0.45`, `mate in 2`, capture annotations, a short
+ * expected line).
+ */
+
+import { Chess, validateFen } from 'chess.js';
+
+export type SideToMove = 'white' | 'black';
+
+export type TopMove = {
+  rank: number;
+  /** SAN, human-readable, e.g. "Nf3". */
+  move: string;
+  /** "+0.45", "-1.20", or "mate in 2". */
+  eval: string;
+  /** Expected continuation in SAN, starting with `move` itself. */
+  line: string[];
+};
+
+/** Plies of the engine line kept for coaching: two moves each side. */
+export const PV_PLIES = 4;
+
+export function fullFen(placement: string, sideToMove: SideToMove): string {
+  const board = placement.trim().split(/\s+/)[0];
+  return `${board} ${sideToMove === 'white' ? 'w' : 'b'} - - 0 1`;
+}
+
+/**
+ * Human-readable reason the FEN is not a legal position, or null if legal.
+ *
+ * Mirrors the backend's `describe_invalidity`. chess.js's `validateFen`
+ * covers syntax, kings, and pawns on the edge ranks; on top of that come
+ * the piece-count checks and the impossible-position check (the side NOT
+ * to move already in check). Wasm Stockfish misbehaves on illegal
+ * positions, so this runs before every search.
+ */
+export function describeInvalidity(fen: string): string | null {
+  const structural = validateFen(fen);
+  if (!structural.ok) return structural.error ?? 'the FEN is not valid';
+
+  const board = fen.split(/\s+/)[0];
+  const count = (re: RegExp) => (board.match(re) ?? []).length;
+  const reasons: string[] = [];
+  if (count(/P/g) > 8) reasons.push('too many white pawns');
+  if (count(/p/g) > 8) reasons.push('too many black pawns');
+  if (count(/[A-Z]/g) > 16) reasons.push('too many white pieces');
+  if (count(/[a-z]/g) > 16) reasons.push('too many black pieces');
+  if (reasons.length > 0) return reasons.join('; ');
+
+  try {
+    new Chess(fen);
+  } catch (error) {
+    return `the FEN doesn't parse (${(error as Error).message})`;
+  }
+  // A position where the side NOT to move is already in check cannot occur
+  // in a real game. chess.js only exposes check for the side to move, so
+  // flip the turn and ask again.
+  const flipped = fen.replace(/ (w|b) /, (m) => (m === ' w ' ? ' b ' : ' w '));
+  try {
+    if (new Chess(flipped).isCheck()) {
+      return (
+        'the side NOT to move is in check, which is impossible on this turn — ' +
+        're-check the kings and the pieces attacking them'
+      );
+    }
+  } catch {
+    // The flipped position can be unloadable for reasons the real one is
+    // not; the original parsed, so let the engine have it.
+  }
+  return null;
+}
+
+/** Mirrors the backend's eval rendering: mate folded to words, cp to pawns. */
+export function formatEval(scoreCp: number, mateIn: number | null): string {
+  if (mateIn !== null) {
+    return `mate in ${Math.abs(mateIn)}` + (mateIn > 0 ? '' : ' (against)');
+  }
+  const pawns = scoreCp / 100;
+  return `${pawns >= 0 ? '+' : ''}${pawns.toFixed(2)}`;
+}
+
+/**
+ * Renders a UCI principal variation as SAN, played out on a copy, truncated
+ * to `PV_PLIES` — a coach uses the next couple of moves for each side, and a
+ * 20-ply line is noise the model would read aloud.
+ */
+export function pvToSan(fen: string, pv: string[]): string[] {
+  const replay = new Chess(fen);
+  const line: string[] = [];
+  for (const uci of pv.slice(0, PV_PLIES)) {
+    try {
+      const move = replay.move({
+        from: uci.slice(0, 2),
+        to: uci.slice(2, 4),
+        promotion: uci.length > 4 ? uci.slice(4) : undefined,
+      });
+      line.push(move.san);
+    } catch {
+      break;
+    }
+  }
+  return line;
+}
+
+const PIECE_NAMES: Record<string, string> = {
+  p: 'pawn',
+  n: 'knight',
+  b: 'bishop',
+  r: 'rook',
+  q: 'queen',
+  k: 'king',
+};
+
+/**
+ * Renders the moves, naming the captured piece + square for any capture, so
+ * the model coaches from ground truth instead of guessing what it can take.
+ */
+export function annotateMoves(fen: string, moves: TopMove[]): string {
+  const parts: string[] = [];
+  for (const m of moves) {
+    let label = `${m.move} (${m.eval})`;
+    try {
+      const position = new Chess(fen);
+      const played = position.move(m.move);
+      if (played.isEnPassant()) {
+        label += ' — captures a pawn en passant';
+      } else if (played.captured) {
+        label += ` — captures the ${PIECE_NAMES[played.captured]} on ${played.to}`;
+      }
+    } catch {
+      // An unplayable SAN just goes unannotated.
+    }
+    // The continuation is what turns "Nf3 is best" into something coachable:
+    // it names the reply the student should be looking for.
+    if (m.line.length > 1) {
+      label += ` — expect ${m.line.join(' ')}`;
+    }
+    parts.push(label);
+  }
+  return parts.join('; ');
+}

--- a/examples/typescript/chess-referee/src/analysis/stockfish.d.ts
+++ b/examples/typescript/chess-referee/src/analysis/stockfish.d.ts
@@ -1,0 +1,9 @@
+/** The `stockfish` package ships no types; only the Node loader is imported
+ *  (in tests) — the browser loads the engine .js directly as a worker. */
+declare module 'stockfish' {
+  function initEngine(flavor?: string): Promise<{
+    sendCommand: (command: string) => void;
+    listener: ((line: string) => void) | undefined;
+  }>;
+  export default initEngine;
+}

--- a/examples/typescript/chess-referee/src/analysis/stockfish_transport.ts
+++ b/examples/typescript/chess-referee/src/analysis/stockfish_transport.ts
@@ -1,0 +1,53 @@
+/**
+ * Browser transport: the `stockfish` package's engine .js is itself a
+ * worker script speaking UCI over postMessage, so the Worker IS the engine.
+ *
+ * The single-threaded lite build is deliberate: the multithreaded builds
+ * need SharedArrayBuffer and therefore COOP/COEP headers on every response,
+ * which most dev servers and static hosts don't send. Single-threaded lite
+ * reaches coaching depth sub-second and runs anywhere.
+ *
+ * The engine .js + .wasm are copied to `public/stockfish/` at install time
+ * (scripts/copy_stockfish.mjs): the emscripten loader fetches the .wasm
+ * relative to the script URL, which a bundler-transformed worker URL would
+ * break.
+ */
+
+import { UciEngine, type UciTransport } from './engine';
+
+export const STOCKFISH_WORKER_URL = '/stockfish/stockfish-18-lite-single.js';
+
+export function createStockfishTransport(
+  workerUrl: string = STOCKFISH_WORKER_URL,
+): UciTransport {
+  const worker = new Worker(workerUrl);
+  return {
+    send: (command) => worker.postMessage(command),
+    onLine: (listener) => {
+      worker.addEventListener('message', (event: MessageEvent<string>) => {
+        listener(String(event.data));
+      });
+    },
+    terminate: () => worker.terminate(),
+  };
+}
+
+let engine: UciEngine | null = null;
+
+/** One engine for the app, started on first use (or by {@link warmAnalysisEngine}). */
+export function analysisEngine(): UciEngine {
+  if (engine === null) {
+    engine = new UciEngine(createStockfishTransport());
+  }
+  return engine;
+}
+
+/** Start the worker + wasm load early so the first tool call doesn't pay it. */
+export function warmAnalysisEngine(): void {
+  analysisEngine();
+}
+
+export function disposeAnalysisEngine(): void {
+  engine?.close();
+  engine = null;
+}

--- a/examples/typescript/chess-referee/src/board_vision.ts
+++ b/examples/typescript/chess-referee/src/board_vision.ts
@@ -24,20 +24,33 @@ export type BoardVisionConfig = {
   apiKey: string;
 };
 
-const ENDPOINT_PATH = '/api/v1/chess/board-position';
+const ENDPOINT_PATH = '/api/v1/external/chess/board-position';
+
+async function toBase64(blob: Blob): Promise<string> {
+  const bytes = new Uint8Array(await blob.arrayBuffer());
+  let binary = '';
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(binary);
+}
 
 export async function readBoardPosition(
   config: BoardVisionConfig,
   frame: Blob,
   orientation?: BoardOrientation,
 ): Promise<BoardPositionResult> {
-  const form = new FormData();
-  form.append('image', frame, 'board.jpg');
-  if (orientation !== undefined) form.append('orientation', orientation);
   const res = await fetch(`${config.baseUrl.replace(/\/$/, '')}${ENDPOINT_PATH}`, {
     method: 'POST',
-    headers: { Authorization: `Bearer ${config.apiKey}` },
-    body: form,
+    headers: {
+      Authorization: `Bearer ${config.apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      image_base64: await toBase64(frame),
+      ...(orientation !== undefined ? { orientation } : {}),
+    }),
   });
   if (!res.ok) {
     throw new Error(`board-position endpoint returned ${res.status}`);

--- a/examples/typescript/chess-referee/src/board_vision.ts
+++ b/examples/typescript/chess-referee/src/board_vision.ts
@@ -1,0 +1,46 @@
+/** Client for the Cosmo board-vision endpoint: a board image in, its FEN
+ *  placement out. The heavy lifting (piece detection, orientation and
+ *  legality resolution) happens server-side — this app never runs a vision
+ *  model. */
+
+export type BoardOrientation = 'white' | 'black';
+
+/** Mirrors the endpoint's response, which is the same shape the backend's
+ *  board-reading tool has always returned. */
+export type BoardPositionResult = {
+  status: 'ok' | 'unreadable' | 'uncertain' | 'error';
+  /** FEN placement field only (no side-to-move). */
+  placement?: string | null;
+  orientation?: BoardOrientation | null;
+  coach_hint?: string;
+  /** Best-guess placement + the specific legality flaw, when no orientation
+   *  produced a legal read. */
+  candidate_placement?: string | null;
+  candidate_flaw?: string | null;
+};
+
+export type BoardVisionConfig = {
+  baseUrl: string;
+  apiKey: string;
+};
+
+const ENDPOINT_PATH = '/api/v1/chess/board-position';
+
+export async function readBoardPosition(
+  config: BoardVisionConfig,
+  frame: Blob,
+  orientation?: BoardOrientation,
+): Promise<BoardPositionResult> {
+  const form = new FormData();
+  form.append('image', frame, 'board.jpg');
+  if (orientation !== undefined) form.append('orientation', orientation);
+  const res = await fetch(`${config.baseUrl.replace(/\/$/, '')}${ENDPOINT_PATH}`, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${config.apiKey}` },
+    body: form,
+  });
+  if (!res.ok) {
+    throw new Error(`board-position endpoint returned ${res.status}`);
+  }
+  return (await res.json()) as BoardPositionResult;
+}

--- a/examples/typescript/chess-referee/src/frame_capture.ts
+++ b/examples/typescript/chess-referee/src/frame_capture.ts
@@ -1,0 +1,46 @@
+/** Grabs still frames from a live camera or screen-share track by playing the
+ *  stream into an off-screen <video> and drawing it to a canvas at the track's
+ *  full capture resolution. */
+export class FrameCapture {
+  private video: HTMLVideoElement;
+  private canvas = document.createElement('canvas');
+  private ready: Promise<void>;
+
+  constructor(readonly stream: MediaStream) {
+    this.video = document.createElement('video');
+    this.video.muted = true;
+    this.video.playsInline = true;
+    this.video.srcObject = stream;
+    this.ready = this.video.play().then(() => {
+      if (this.video.videoWidth > 0) return;
+      return new Promise<void>((resolve) => {
+        this.video.addEventListener('loadedmetadata', () => resolve(), { once: true });
+      });
+    });
+  }
+
+  async capture(type = 'image/jpeg', quality = 0.9): Promise<Blob> {
+    await this.ready;
+    const { videoWidth, videoHeight } = this.video;
+    if (videoWidth === 0 || videoHeight === 0) {
+      throw new Error('video track has no frames yet');
+    }
+    this.canvas.width = videoWidth;
+    this.canvas.height = videoHeight;
+    const ctx = this.canvas.getContext('2d');
+    if (ctx === null) throw new Error('canvas 2d context unavailable');
+    ctx.drawImage(this.video, 0, 0, videoWidth, videoHeight);
+    return new Promise<Blob>((resolve, reject) => {
+      this.canvas.toBlob(
+        (blob) => (blob !== null ? resolve(blob) : reject(new Error('frame encode failed'))),
+        type,
+        quality,
+      );
+    });
+  }
+
+  dispose(): void {
+    this.video.srcObject = null;
+    for (const track of this.stream.getTracks()) track.stop();
+  }
+}

--- a/examples/typescript/chess-referee/src/frame_capture.ts
+++ b/examples/typescript/chess-referee/src/frame_capture.ts
@@ -19,7 +19,7 @@ export class FrameCapture {
     });
   }
 
-  async capture(type = 'image/jpeg', quality = 0.9): Promise<Blob> {
+  async capture(type = 'image/jpeg', quality = 0.8): Promise<Blob> {
     await this.ready;
     const { videoWidth, videoHeight } = this.video;
     if (videoWidth === 0 || videoHeight === 0) {

--- a/examples/typescript/chess-referee/src/index.css
+++ b/examples/typescript/chess-referee/src/index.css
@@ -1,0 +1,317 @@
+:root {
+  --ground: #0B0C0A;
+  --raised: #141613;
+  --raised-2: #1C1F1A;
+  --line: #2A2E27;
+  --line-bright: #3D423A;
+  --ink: #F0F2EC;
+  --ink-soft: #A8AEA0;
+  --ink-faint: #6B7264;
+  --accent: #C8F751;
+  --accent-dim: #9BC22F;
+  --accent-wash: #1E2610;
+  --hot: #FF7A5C;
+  --hot-wash: #2A1712;
+
+  --sans: ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+  --mono: ui-monospace, "SF Mono", SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+* { box-sizing: border-box; }
+
+html, body, #root { height: 100%; }
+
+body {
+  margin: 0;
+  background: var(--ground);
+  color: var(--ink);
+  font-family: var(--sans);
+  line-height: 1.55;
+  -webkit-font-smoothing: antialiased;
+}
+
+/* Ambient wash so the page doesn't read as a flat black rectangle. */
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  background:
+    radial-gradient(60rem 40rem at 70% -10%, #1A2110 0%, transparent 60%),
+    radial-gradient(50rem 30rem at 0% 100%, #16180F 0%, transparent 55%);
+  pointer-events: none;
+  z-index: 0;
+}
+
+.shell {
+  position: relative;
+  z-index: 1;
+  max-width: 46rem;
+  margin: 0 auto;
+  padding: clamp(2rem, 6vw, 4.5rem) clamp(1.1rem, 4vw, 2rem) 6rem;
+}
+
+/* ---------- masthead ---------- */
+.masthead { margin-bottom: 2.5rem; }
+
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 0.7rem;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--accent-dim);
+  margin: 0 0 0.7rem;
+}
+
+h1 {
+  font-size: clamp(2.4rem, 9vw, 3.6rem);
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+  font-weight: 800;
+  margin: 0 0 0.6rem;
+  text-wrap: balance;
+}
+
+.lede {
+  color: var(--ink-soft);
+  font-size: 1.02rem;
+  max-width: 38ch;
+  margin: 0;
+}
+
+/* ---------- buttons ---------- */
+.btn {
+  font: inherit;
+  font-weight: 650;
+  border: none;
+  border-radius: 10px;
+  padding: 0.78rem 1.5rem;
+  cursor: pointer;
+  transition: background 0.15s, opacity 0.15s, transform 0.1s;
+}
+.btn:active:not(:disabled) { transform: translateY(1px); }
+.btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.btn-primary { background: var(--accent); color: #10130A; width: 100%; margin-top: 1rem; }
+.btn-primary:hover:not(:disabled) { background: #D6FF6B; }
+.btn-primary:disabled { background: var(--raised-2); color: var(--ink-faint); cursor: default; }
+.btn-ghost {
+  background: transparent;
+  color: var(--ink-soft);
+  border: 1px solid var(--line-bright);
+  padding: 0.45rem 0.95rem;
+  font-size: 0.86rem;
+  font-weight: 550;
+  border-radius: 8px;
+}
+.btn-ghost:hover { color: var(--ink); border-color: var(--ink-faint); }
+
+@keyframes pulse { 50% { opacity: 0.45; } }
+@media (prefers-reduced-motion: reduce) {
+  .status.live .status-dot { animation: none; }
+  .btn { transition: none; }
+}
+
+/* ---------- session ---------- */
+.session-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.7rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.2rem;
+}
+.status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-family: var(--mono);
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  padding: 0.34rem 0.7rem;
+  border-radius: 99px;
+  background: var(--raised-2);
+  color: var(--ink-soft);
+  border: 1px solid var(--line);
+}
+.status.live { background: var(--accent-wash); color: var(--accent); border-color: transparent; }
+.status.bad { background: var(--hot-wash); color: var(--hot); border-color: transparent; }
+.status-dot { width: 6px; height: 6px; border-radius: 99px; background: currentColor; }
+.status.live .status-dot { animation: pulse 1.8s ease-in-out infinite; }
+
+video {
+  width: 100%;
+  border-radius: 12px;
+  background: #000;
+  display: block;
+  border: 1px solid var(--line);
+}
+
+.verdict {
+  width: 100%;
+  margin-top: 0.7rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 10px;
+  background: var(--raised-2);
+  border: 1px solid var(--line);
+  color: var(--ink-soft);
+  font-family: var(--mono);
+  font-size: 0.82rem;
+  text-align: center;
+}
+.verdict.bad {
+  background: var(--hot-wash);
+  color: var(--hot);
+  border-color: color-mix(in srgb, var(--hot) 30%, transparent);
+}
+
+.transcript { display: flex; flex-direction: column; gap: 0.55rem; margin-top: 1.4rem; }
+.bubble {
+  max-width: 82%;
+  padding: 0.6rem 0.9rem;
+  border-radius: 14px;
+  font-size: 0.93rem;
+}
+.bubble.assistant {
+  align-self: flex-start;
+  background: var(--raised);
+  border: 1px solid var(--line);
+  border-bottom-left-radius: 5px;
+}
+.bubble.user {
+  align-self: flex-end;
+  background: var(--accent);
+  color: #10130A;
+  border-bottom-right-radius: 5px;
+  font-weight: 500;
+}
+.bubble.partial { opacity: 0.55; }
+
+.empty {
+  color: var(--ink-faint);
+  font-size: 0.9rem;
+  text-align: center;
+  padding: 1.6rem 0;
+}
+
+/* ---------- settings disclosure ---------- */
+details.settings { margin-top: 1.6rem; }
+details.settings summary {
+  cursor: pointer;
+  color: var(--ink-faint);
+  font-size: 0.84rem;
+  list-style: none;
+  padding: 0.4rem 0;
+  user-select: none;
+}
+details.settings summary::-webkit-details-marker { display: none; }
+details.settings summary::before { content: "▸ "; color: var(--line-bright); }
+details[open].settings summary::before { content: "▾ "; }
+details.settings summary:hover { color: var(--ink-soft); }
+
+.field-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.9rem;
+}
+@media (max-width: 34rem) {
+  .field-row { grid-template-columns: 1fr; }
+}
+
+.field { display: flex; flex-direction: column; gap: 0.3rem; margin-top: 0.8rem; }
+.field label {
+  font-size: 0.74rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+}
+.field input,
+.field select {
+  font: inherit;
+  font-family: var(--mono);
+  font-size: 0.84rem;
+  background: var(--raised);
+  border: 1px solid var(--line-bright);
+  color: var(--ink);
+  border-radius: 8px;
+  padding: 0.55rem 0.7rem;
+}
+.field input:focus,
+.field select:focus { outline: none; border-color: var(--accent-dim); }
+
+.err {
+  background: var(--hot-wash);
+  border: 1px solid color-mix(in srgb, var(--hot) 30%, transparent);
+  color: var(--hot);
+  border-radius: 10px;
+  padding: 0.75rem 1rem;
+  font-size: 0.88rem;
+  margin-top: 1rem;
+}
+
+.hint { color: var(--ink-faint); font-size: 0.82rem; margin: 0.7rem 0 0; }
+
+/* ---------- session layout ---------- */
+/* Wider only in session: the setup step reads better narrow. */
+.shell.wide { max-width: 72rem; }
+
+.session-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 1fr);
+  gap: 1.4rem;
+  align-items: start;
+}
+@media (max-width: 60rem) {
+  .session-grid { grid-template-columns: 1fr; }
+}
+
+.stage-col {
+  position: sticky;
+  top: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background: var(--raised);
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 0.7rem;
+}
+@media (max-width: 60rem) {
+  .stage-col { position: static; }
+}
+
+.stage-col video {
+  max-height: 62vh;
+  max-width: 100%;
+  width: auto;
+  border: none;
+  border-radius: 10px;
+}
+
+.chat-col {
+  display: flex;
+  flex-direction: column;
+  min-height: 22rem;
+  max-height: 74vh;
+}
+
+.transcript.scroll {
+  overflow-y: auto;
+  flex: 1;
+  padding-right: 0.35rem;
+  margin-top: 0;
+  scrollbar-width: thin;
+  scrollbar-color: var(--line-bright) transparent;
+}
+.transcript.scroll::-webkit-scrollbar { width: 7px; }
+.transcript.scroll::-webkit-scrollbar-thumb {
+  background: var(--line-bright);
+  border-radius: 99px;
+}
+
+.chat-head {
+  font-family: var(--mono);
+  font-size: 0.68rem;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  color: var(--ink-faint);
+  margin: 0 0 0.8rem;
+}

--- a/examples/typescript/chess-referee/src/instructions.ts
+++ b/examples/typescript/chess-referee/src/instructions.ts
@@ -1,0 +1,25 @@
+/** Tag prefixing the synthetic turn that asks the agent to speak up. Context
+ *  notes never trigger a spoken response by design, so the referee moment is
+ *  a regular text turn, sent with `transcript: false` so the user never sees
+ *  the directive itself. */
+export const REFEREE_ALERT_TAG = '[referee-alert]';
+
+export const REFEREE_INSTRUCTIONS = `\
+You are a lively chess referee and companion watching a chess game through \
+the player's camera.
+
+You continuously receive board state as context notes tagged [board]: the \
+current FEN, the last move played, and whose turn it is. Track the game \
+silently — never narrate or comment on routine legal moves unless asked.
+
+When you receive a message tagged ${REFEREE_ALERT_TAG}, a rules violation \
+just happened on the board. Immediately call it out loud: name the violation \
+in one short, confident, playful sentence (like a friendly club arbiter), \
+then tell the players how to fix it (return the piece, make a legal move). \
+Keep it under two sentences.
+
+Players may also ask you questions — the position, whose turn it is, what \
+just happened. Answer from the [board] notes; if the position might have \
+changed since the last note, call get_chess_board_position for a fresh read \
+rather than guessing. Stay warm and brief; this is a family game, not a \
+broadcast booth.`;

--- a/examples/typescript/chess-referee/src/instructions.ts
+++ b/examples/typescript/chess-referee/src/instructions.ts
@@ -22,4 +22,11 @@ Players may also ask you questions — the position, whose turn it is, what \
 just happened. Answer from the [board] notes; if the position might have \
 changed since the last note, call get_chess_board_position for a fresh read \
 rather than guessing. Stay warm and brief; this is a family game, not a \
-broadcast booth.`;
+broadcast booth.
+
+When a player asks for advice — what to play, whether a move was good, how \
+the game stands — call get_chess_board_position, then pass its placement to \
+analyze_position with whose turn it is. Coach from the returned moves \
+conversationally: point at the idea (the hanging piece, the threat, the \
+plan), not the whole engine line, and never recite variations or \
+evaluations unless asked.`;

--- a/examples/typescript/chess-referee/src/main.tsx
+++ b/examples/typescript/chess-referee/src/main.tsx
@@ -1,0 +1,11 @@
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+
+import { App } from './App';
+import './index.css';
+
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/typescript/chess-referee/src/referee.test.ts
+++ b/examples/typescript/chess-referee/src/referee.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+import { Chess } from 'chess.js';
+
+import { placementOf, Referee, START_PLACEMENT, type RefereeEvent } from './referee';
+
+/** Feed one placement enough times to clear the stability gate. */
+function feedStable(referee: Referee, placement: string, threshold = 2): RefereeEvent | null {
+  let event: RefereeEvent | null = null;
+  for (let i = 0; i < threshold; i++) {
+    event = referee.ingest(placement);
+  }
+  return event;
+}
+
+function placementAfter(moves: string[]): string {
+  const chess = new Chess();
+  for (const san of moves) chess.move(san);
+  return placementOf(chess.fen());
+}
+
+function startGame(referee: Referee): void {
+  expect(feedStable(referee, START_PLACEMENT)).toEqual({ kind: 'game_started' });
+}
+
+describe('stability gate', () => {
+  it('ignores a placement seen fewer times than the threshold', () => {
+    const referee = new Referee(3);
+    expect(referee.ingest(START_PLACEMENT)).toBeNull();
+    expect(referee.ingest(START_PLACEMENT)).toBeNull();
+    expect(referee.ingest(START_PLACEMENT)).toEqual({ kind: 'game_started' });
+  });
+
+  it('resets the count when the read flickers', () => {
+    const referee = new Referee(2);
+    expect(referee.ingest(START_PLACEMENT)).toBeNull();
+    expect(referee.ingest('8/8/8/8/8/8/8/8')).toBeNull();
+    expect(referee.ingest(START_PLACEMENT)).toBeNull();
+    expect(referee.ingest(START_PLACEMENT)).toEqual({ kind: 'game_started' });
+  });
+
+  it('fires once per stable position, not on every following read', () => {
+    const referee = new Referee(2);
+    startGame(referee);
+    expect(referee.ingest(START_PLACEMENT)).toBeNull();
+  });
+});
+
+describe('move inference', () => {
+  it('recognizes a legal move with its SAN and mover', () => {
+    const referee = new Referee(2);
+    startGame(referee);
+    const event = feedStable(referee, placementAfter(['e4']));
+    expect(event).toMatchObject({ kind: 'legal_move', san: 'e4', mover: 'white' });
+    expect(referee.sideToMove).toBe('black');
+  });
+
+  it('follows a full sequence including a capture', () => {
+    const referee = new Referee(2);
+    startGame(referee);
+    const moves: string[] = [];
+    for (const san of ['e4', 'd5', 'exd5']) {
+      moves.push(san);
+      const event = feedStable(referee, placementAfter(moves));
+      expect(event).toMatchObject({ kind: 'legal_move', san });
+    }
+  });
+
+  it('recognizes castling as one move despite two pieces changing', () => {
+    const referee = new Referee(2);
+    startGame(referee);
+    const moves: string[] = [];
+    for (const san of ['e4', 'e5', 'Nf3', 'Nc6', 'Bc4', 'Bc5', 'O-O']) {
+      moves.push(san);
+      const event = feedStable(referee, placementAfter(moves));
+      expect(event).toMatchObject({ kind: 'legal_move', san });
+    }
+  });
+
+  it('flags a legal move played by the wrong side without advancing the game', () => {
+    const referee = new Referee(2);
+    startGame(referee);
+    feedStable(referee, placementAfter(['e4']));
+    // White moves again instead of black.
+    const chess = new Chess();
+    chess.move('e4');
+    const fenParts = chess.fen().split(' ');
+    fenParts[1] = 'w';
+    fenParts[3] = '-';
+    const white2 = new Chess(fenParts.join(' '));
+    white2.move('Nf3');
+    const event = feedStable(referee, placementOf(white2.fen()));
+    expect(event).toMatchObject({ kind: 'out_of_turn', san: 'Nf3', mover: 'white' });
+    expect(referee.sideToMove).toBe('black');
+  });
+
+  it('flags an unreachable small change as an illegal move', () => {
+    const referee = new Referee(2);
+    startGame(referee);
+    // The b1 knight teleports to b3 — no legal knight move from the start.
+    const observed = 'rnbqkbnr/pppppppp/8/8/8/1N6/PPPPPPPP/R1BQKBNR';
+    const event = feedStable(referee, observed);
+    expect(event).toMatchObject({ kind: 'illegal_move', observed });
+    if (event?.kind === 'illegal_move') {
+      expect(event.description).toContain('b1');
+      expect(event.description).toContain('b3');
+    }
+    expect(referee.placement).toBe(START_PLACEMENT);
+  });
+
+  it('rules a many-square change a scrambled board', () => {
+    const referee = new Referee(2);
+    startGame(referee);
+    const event = feedStable(referee, '8/8/8/8/8/8/8/8');
+    expect(event).toMatchObject({ kind: 'board_scrambled' });
+  });
+});
+
+describe('game lifecycle', () => {
+  it('stays silent before the starting position appears', () => {
+    const referee = new Referee(2);
+    expect(feedStable(referee, placementAfter(['e4']))).toBeNull();
+    expect(referee.gameStarted).toBe(false);
+  });
+
+  it('startNewGame resets state and waits for a fresh start', () => {
+    const referee = new Referee(2);
+    startGame(referee);
+    feedStable(referee, placementAfter(['e4']));
+    referee.startNewGame();
+    expect(referee.gameStarted).toBe(false);
+    expect(feedStable(referee, START_PLACEMENT)).toEqual({ kind: 'game_started' });
+  });
+});

--- a/examples/typescript/chess-referee/src/referee.ts
+++ b/examples/typescript/chess-referee/src/referee.ts
@@ -1,0 +1,222 @@
+import { Chess } from 'chess.js';
+
+/** What the referee concluded from a stable board change. */
+export type RefereeEvent =
+  /** The game began: the starting position was recognized. */
+  | { kind: 'game_started' }
+  /** A legal move was played. `fen` is the full FEN after the move. */
+  | { kind: 'legal_move'; san: string; mover: 'white' | 'black'; fen: string }
+  /** The observed position is not reachable by any legal move. */
+  | { kind: 'illegal_move'; description: string; observed: string }
+  /** A legal move — but by the side whose turn it isn't. */
+  | { kind: 'out_of_turn'; san: string; mover: 'white' | 'black' }
+  /** Pieces changed in a way no single move explains (knocked pieces,
+   *  mid-move hand, takeback). */
+  | { kind: 'board_scrambled'; observed: string };
+
+export const START_PLACEMENT = 'rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR';
+
+export function placementOf(fen: string): string {
+  return fen.split(' ')[0];
+}
+
+type Grid = (string | null)[][];
+
+/** Expand a FEN placement into an 8×8 grid; row 0 is rank 8. */
+function gridOf(placement: string): Grid | null {
+  const ranks = placement.split('/');
+  if (ranks.length !== 8) return null;
+  const grid: Grid = [];
+  for (const rank of ranks) {
+    const row: (string | null)[] = [];
+    for (const ch of rank) {
+      if (ch >= '1' && ch <= '8') {
+        for (let i = 0; i < Number(ch); i++) row.push(null);
+      } else {
+        row.push(ch);
+      }
+    }
+    if (row.length !== 8) return null;
+    grid.push(row);
+  }
+  return grid;
+}
+
+function squareName(row: number, col: number): string {
+  return `${String.fromCharCode(97 + col)}${8 - row}`;
+}
+
+function pieceName(fenChar: string): string {
+  const color = fenChar === fenChar.toUpperCase() ? 'white' : 'black';
+  const names: Record<string, string> = {
+    p: 'pawn', r: 'rook', n: 'knight', b: 'bishop', q: 'queen', k: 'king',
+  };
+  return `${color} ${names[fenChar.toLowerCase()] ?? 'piece'}`;
+}
+
+function changedSquares(before: Grid, after: Grid): { row: number; col: number }[] {
+  const diffs: { row: number; col: number }[] = [];
+  for (let row = 0; row < 8; row++) {
+    for (let col = 0; col < 8; col++) {
+      if (before[row][col] !== after[row][col]) diffs.push({ row, col });
+    }
+  }
+  return diffs;
+}
+
+function describeIllegalChange(
+  diffs: { row: number; col: number }[],
+  before: Grid,
+  after: Grid,
+): string {
+  const vacated: { square: string; piece: string }[] = [];
+  const arrived: { square: string; piece: string }[] = [];
+  for (const { row, col } of diffs) {
+    const square = squareName(row, col);
+    const was = before[row][col];
+    const now = after[row][col];
+    if (was !== null && now === null) vacated.push({ square, piece: was });
+    if (now !== null && was !== now) arrived.push({ square, piece: now });
+  }
+  const from = vacated[0];
+  const to = arrived[0];
+  if (from && to) {
+    return `${pieceName(from.piece)} from ${from.square} to ${to.square} — not a legal move here`;
+  }
+  const squares = diffs.map((d) => squareName(d.row, d.col)).join(', ');
+  return `position changed on ${squares} in a way no legal move allows`;
+}
+
+/** Turns a stream of noisy board reads into confident game events.
+ *
+ *  Two jobs: a stability gate (a placement must be read identically on
+ *  `stabilityThreshold` consecutive reads before it counts), and move
+ *  inference — diff the accepted placement against the game state and find
+ *  the legal move that explains it, or rule the change illegal.
+ *
+ *  Reads arrive already oriented (white's back rank last) — the vision
+ *  endpoint resolves board orientation before we see the placement.
+ */
+export class Referee {
+  private chess = new Chess();
+  private started = false;
+  private pending: string | null = null;
+  private pendingCount = 0;
+
+  constructor(private readonly stabilityThreshold: number = 2) {}
+
+  get fen(): string {
+    return this.chess.fen();
+  }
+
+  get placement(): string {
+    return placementOf(this.chess.fen());
+  }
+
+  get sideToMove(): 'white' | 'black' {
+    return this.chess.turn() === 'w' ? 'white' : 'black';
+  }
+
+  get gameStarted(): boolean {
+    return this.started;
+  }
+
+  /** Reset to a fresh game; events resume once the starting position is
+   *  recognized again. */
+  startNewGame(): void {
+    this.chess = new Chess();
+    this.started = false;
+    this.pending = null;
+    this.pendingCount = 0;
+  }
+
+  /** Feed one read's placement. Returns an event only when a stable,
+   *  *changed* position was accepted and classified. */
+  ingest(placement: string): RefereeEvent | null {
+    if (placement === this.pending) {
+      this.pendingCount += 1;
+    } else {
+      this.pending = placement;
+      this.pendingCount = 1;
+    }
+    if (this.pendingCount !== this.stabilityThreshold) return null;
+
+    if (!this.started) {
+      if (placement === START_PLACEMENT) {
+        this.started = true;
+        return { kind: 'game_started' };
+      }
+      return null;
+    }
+
+    if (placement === this.placement) return null;
+    return this.classify(placement);
+  }
+
+  private classify(observed: string): RefereeEvent {
+    const san = this.legalMoveExplaining(observed, this.chess.fen());
+    if (san !== null) {
+      const mover = this.sideToMove;
+      this.chess.move(san);
+      return { kind: 'legal_move', san, mover, fen: this.chess.fen() };
+    }
+
+    // A legal move for the *other* side? That's a real board event worth
+    // calling out differently: someone moved out of turn. The game state
+    // stays where it was — the move needs to be taken back.
+    const toggled = this.toggledSideFen();
+    if (toggled !== null) {
+      const sanOther = this.legalMoveExplaining(observed, toggled);
+      if (sanOther !== null) {
+        const mover = this.sideToMove === 'white' ? 'black' : 'white';
+        return { kind: 'out_of_turn', san: sanOther, mover };
+      }
+    }
+
+    // No single legal move explains the change. A 1–4 square diff reads as
+    // an attempted (illegal) move; anything bigger is a scrambled board.
+    const before = gridOf(this.placement);
+    const after = gridOf(observed);
+    if (before === null || after === null) {
+      return { kind: 'board_scrambled', observed };
+    }
+    const diffs = changedSquares(before, after);
+    if (diffs.length < 1 || diffs.length > 4) {
+      return { kind: 'board_scrambled', observed };
+    }
+    return {
+      kind: 'illegal_move',
+      description: describeIllegalChange(diffs, before, after),
+      observed,
+    };
+  }
+
+  /** Search every legal move of `fen`'s side to move for one whose resulting
+   *  placement matches `observed`. Promotions are separate verbose moves, so
+   *  every promotion piece is covered. */
+  private legalMoveExplaining(observed: string, fen: string): string | null {
+    const base = new Chess(fen);
+    for (const move of base.moves({ verbose: true })) {
+      const candidate = new Chess(fen);
+      candidate.move(move.san);
+      if (placementOf(candidate.fen()) === observed) return move.san;
+    }
+    return null;
+  }
+
+  /** Current position with the side to move flipped and en passant cleared,
+   *  or null when the flip is not a valid position (e.g. the mover left the
+   *  opponent in check). */
+  private toggledSideFen(): string | null {
+    const parts = this.chess.fen().split(' ');
+    parts[1] = parts[1] === 'w' ? 'b' : 'w';
+    parts[3] = '-';
+    const fen = parts.join(' ');
+    try {
+      new Chess(fen);
+      return fen;
+    } catch {
+      return null;
+    }
+  }
+}

--- a/examples/typescript/chess-referee/src/referee_loop.ts
+++ b/examples/typescript/chess-referee/src/referee_loop.ts
@@ -1,0 +1,64 @@
+import type { BoardOrientation, BoardVisionConfig } from './board_vision';
+import { readBoardPosition } from './board_vision';
+import type { FrameCapture } from './frame_capture';
+import type { Referee, RefereeEvent } from './referee';
+
+export type RefereeLoopOptions = {
+  capture: FrameCapture;
+  vision: BoardVisionConfig;
+  referee: Referee;
+  /** Pin the board orientation instead of letting the endpoint detect it.
+   *  The starting position is legal from both sides, so detection can lock
+   *  the wrong way on move one — pinning is the reliable path. */
+  orientation?: BoardOrientation;
+  onEvent: (event: RefereeEvent) => void;
+  onReadError?: (error: unknown) => void;
+  intervalMs?: number;
+};
+
+/** Continuously read the board through the vision endpoint and feed the
+ *  referee. One read in flight at a time; the next starts `intervalMs` after
+ *  the previous settles, so a slow endpoint stretches the cadence instead of
+ *  stacking requests. Returns a stop function. */
+export function startRefereeLoop(options: RefereeLoopOptions): () => void {
+  const { capture, vision, referee, onEvent, onReadError } = options;
+  const intervalMs = options.intervalMs ?? 1500;
+  let stopped = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let detectedOrientation: BoardOrientation | undefined;
+
+  const tick = async (): Promise<void> => {
+    try {
+      const frame = await capture.capture();
+      const result = await readBoardPosition(
+        vision,
+        frame,
+        options.orientation ?? detectedOrientation,
+      );
+      if (stopped) return;
+      // An illegal *position* (say, a pawn shoved to the back rank) comes
+      // back as `uncertain` with the raw read attached — that read is
+      // exactly the evidence an illegal-move verdict needs, so it feeds the
+      // referee like any other observation.
+      const placement =
+        result.status === 'ok' ? result.placement : result.candidate_placement;
+      if (typeof placement === 'string' && placement.length > 0) {
+        if (result.status === 'ok' && result.orientation != null) {
+          detectedOrientation = result.orientation;
+        }
+        const event = referee.ingest(placement);
+        if (event !== null) onEvent(event);
+      }
+    } catch (error) {
+      if (!stopped) onReadError?.(error);
+    } finally {
+      if (!stopped) timer = setTimeout(() => void tick(), intervalMs);
+    }
+  };
+
+  void tick();
+  return () => {
+    stopped = true;
+    if (timer !== undefined) clearTimeout(timer);
+  };
+}

--- a/examples/typescript/chess-referee/src/tools.ts
+++ b/examples/typescript/chess-referee/src/tools.ts
@@ -1,0 +1,61 @@
+import { tool } from 'cosmo-ai/tool';
+import { zodInput } from 'cosmo-ai/tool/zod';
+import { z } from 'zod/v4';
+
+import type { BoardOrientation, BoardVisionConfig } from './board_vision';
+import { readBoardPosition } from './board_vision';
+import type { FrameCapture } from './frame_capture';
+import type { Referee } from './referee';
+
+/** Everything the client tools need from the running app. `analyze_position`
+ *  (client-side stockfish.wasm) will take the same context when it lands. */
+export type ToolContext = {
+  vision: BoardVisionConfig;
+  getCapture: () => FrameCapture | null;
+  referee: Referee;
+  orientation?: BoardOrientation;
+};
+
+export function makeBoardPositionTool(ctx: ToolContext) {
+  return tool({
+    name: 'get_chess_board_position',
+    description:
+      'Read the chess board through the camera and return its FEN placement. ' +
+      'You do NOT read the board yourself — your own reading of a board is ' +
+      'unreliable. Call this whenever you need to know where the pieces are: ' +
+      'to answer any question about the position, or when the streamed board ' +
+      'state seems stale.',
+    input: zodInput(
+      z.object({
+        orientation: z
+          .enum(['white', 'black'])
+          .optional()
+          .describe(
+            "Which side the board is seen from — 'white' if white's pieces are " +
+              'nearest the camera. Omit if unsure; it is detected from the board.',
+          ),
+      }),
+    ),
+    handler: async ({ orientation }) => {
+      const capture = ctx.getCapture();
+      if (capture === null) {
+        return {
+          status: 'unreadable',
+          coach_hint:
+            "The camera isn't running — ask the user to point it at the board. " +
+            'Do not guess the position.',
+        };
+      }
+      const frame = await capture.capture();
+      const result = await readBoardPosition(
+        ctx.vision,
+        frame,
+        orientation ?? ctx.orientation,
+      );
+      if (result.status === 'ok' && ctx.referee.gameStarted) {
+        return { ...result, side_to_move: ctx.referee.sideToMove };
+      }
+      return result;
+    },
+  });
+}

--- a/examples/typescript/chess-referee/src/vite-env.d.ts
+++ b/examples/typescript/chess-referee/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/examples/typescript/chess-referee/tsconfig.json
+++ b/examples/typescript/chess-referee/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "useDefineForClassFields": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "include": ["src"]
+}

--- a/examples/typescript/chess-referee/vite.config.ts
+++ b/examples/typescript/chess-referee/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 7870,
+  },
+});


### PR DESCRIPTION
Closes socratic-ai/cosmo#10566. Closes socratic-ai/cosmo#10567.

**Stacked on socratic-ai/cosmo#10570** (the board-position endpoint) — merge that first; this example POSTs to `/api/v1/external/chess/board-position` and is aligned to its landed contract.

## What

TypeScript-SDK ChessReferee example (`examples/typescript/chess-referee`) where both chess tools are **pure client tools** (the #10540 thin-client architecture):

- `get_chess_board_position` — captures a frame from the local camera/screen track (canvas capture), POSTs it to the board-position endpoint, returns the FEN result to the model unchanged (socratic-ai/cosmo#10566).
- `analyze_position` — client-side stockfish.wasm; FEN + side-to-move in, top moves out (socratic-ai/cosmo#10567).

Referee behavior per #10510's validated design: board state streamed as session context, unprompted interjection on illegal moves.

## Notes

- Image capture does not need high resolution: the backend detector letterboxes to 640px and re-crops small boards — 720p JPEG at ~0.8 quality is verified sufficient (~60 KB per read).
- Auth: the same API key / minted `TokenSource` token used for `RealtimeClient` works against the endpoint (`realtime:use` scope).

https://claude.ai/code/session_01QN8ii3KVeoX7v9RGwP54xJ